### PR TITLE
Allow extrapolation of step time series for the logical check

### DIFF
--- a/Cognite.DataProcessing/DataSampling.cs
+++ b/Cognite.DataProcessing/DataSampling.cs
@@ -98,7 +98,7 @@ namespace Cognite.DataProcessing
         /// <param name="ts">The time series to evaluate</param>
         /// <param name="threshold">The threshold to use for the logical check</param>
         /// <param name="check">The logical check to use</param>
-        /// <param name="endTime">The logical check to use</param>
+        /// <param name="endTime">End time in milliseconds since Epoch</param>
         /// <returns>
         /// Time series with the logical check status (0: conditions not met, 1: conditions met) for all timestamps.
         /// </returns>

--- a/Cognite.DataProcessing/DataSampling.cs
+++ b/Cognite.DataProcessing/DataSampling.cs
@@ -98,16 +98,22 @@ namespace Cognite.DataProcessing
         /// <param name="ts">The time series to evaluate</param>
         /// <param name="threshold">The threshold to use for the logical check</param>
         /// <param name="check">The logical check to use</param>
+        /// <param name="endTime">The logical check to use</param>
         /// <returns>
         /// Time series with the logical check status (0: conditions not met, 1: conditions met) for all timestamps.
         /// </returns>
-        public static TimeSeriesData LogicalCheck(TimeSeriesData ts, double threshold, LogicOperator check)
+        public static TimeSeriesData LogicalCheck(
+            TimeSeriesData ts, double threshold, LogicOperator check, long? endTime = null)
         {
             if (ts == null)
                 throw new ArgumentNullException(nameof(ts), "The input data is empty");
 
-            // resamples the given time series so that it contains equally spaced elements
-            TimeSeriesData resampledTs = ts.EquallySpacedResampling();
+            // We can only resample until the endTime if the time series is of type `step`. If the user specifies an
+            // endTime for a non `step` time series we override it.
+            // TODO: Add logging to notify the user that the endTime is being set to null
+            if (!ts.IsStep)
+                endTime = null;
+            TimeSeriesData resampledTs = ts.EquallySpacedResampling(endTime: endTime);
 
             // store locally the x and y arrays
             long[] x = resampledTs.Time;

--- a/Cognite.Simulator.Tests/DataProcessingTests/DataSamplingTest.cs
+++ b/Cognite.Simulator.Tests/DataProcessingTests/DataSamplingTest.cs
@@ -164,4 +164,46 @@ public class DataSamplingTest
             Assert.Equal(_logicalCheck1.Data[i], logicResult.Data[i]);
         }
     }
+    
+    [Fact]
+    public void TestLogicalCheckExtrapolate()
+    {
+        // input data
+        TimeSeriesData input = new TimeSeriesData(
+            time: new long[] {1, 2, 3}, data: new double[] {5, 0, 3}, granularity: 1, isStep: true);
+
+        TimeSeriesData output = new TimeSeriesData(
+            time: new long[] {1, 2, 3, 4, 5}, data: new double[] {1, 0, 1, 1, 1}, granularity: 1, isStep: true);
+        
+        // Call Method
+        TimeSeriesData logicResult = DataSampling.LogicalCheck(
+            ts: input, threshold: 2.5, check: DataSampling.LogicOperator.Ge, endTime: 5);
+
+        for (int i = 0; i < logicResult.Time.Length; i++)
+        {
+            Assert.Equal(output.Time[i], logicResult.Time[i]);
+            Assert.Equal(output.Data[i], logicResult.Data[i]);
+        }
+    }
+    
+    [Fact]
+    public void TestLogicalCheckTryExtrapolate()
+    {
+        // input data
+        TimeSeriesData input = new TimeSeriesData(
+            time: new long[] {1, 2, 3}, data: new double[] {5, 0, 3}, granularity: 1, isStep: false);
+
+        TimeSeriesData output = new TimeSeriesData(
+            time: new long[] {1, 2, 3}, data: new double[] {1, 0, 1}, granularity: 1, isStep: false);
+        
+        // Call Method
+        TimeSeriesData logicResult = DataSampling.LogicalCheck(
+            ts: input, threshold: 2.5, check: DataSampling.LogicOperator.Ge, endTime: 5);
+
+        for (int i = 0; i < logicResult.Time.Length; i++)
+        {
+            Assert.Equal(output.Time[i], logicResult.Time[i]);
+            Assert.Equal(output.Data[i], logicResult.Data[i]);
+        }
+    }
 }


### PR DESCRIPTION
This PR includes an optional `endTime` parameter to the **Logical Check**. This allows the routine to extrapolate a step time series up to the `endTime` before executing the logical check operation. If a user provides a value for `endTime`, but the provided time series is not of type `step`, we don't extrapolate until the `endTime`.