### PR TITLE
Base class for a simulation runner

### DIFF
--- a/Cognite.Simulator.Extensions/DataModel.cs
+++ b/Cognite.Simulator.Extensions/DataModel.cs
@@ -211,6 +211,9 @@ namespace Cognite.Simulator.Extensions
         /// </summary>
         public const string CalculationIdKey = "calcConfig";
 
+        /// <summary>
+        /// Indicates that the start of the validation time should be overwritten with the metadata value
+        /// </summary>
         public const string ValidationEndOverwriteKey = "validationEndOverwrite";
 
         /// <summary>

--- a/Cognite.Simulator.Extensions/DataModel.cs
+++ b/Cognite.Simulator.Extensions/DataModel.cs
@@ -211,6 +211,8 @@ namespace Cognite.Simulator.Extensions
         /// </summary>
         public const string CalculationIdKey = "calcConfig";
 
+        public const string ValidationEndOverwriteKey = "validationEndOverwrite";
+
         /// <summary>
         /// Data type of simulation events
         /// </summary>

--- a/Cognite.Simulator.Extensions/EventsExtensions.cs
+++ b/Cognite.Simulator.Extensions/EventsExtensions.cs
@@ -377,6 +377,10 @@ namespace Cognite.Simulator.Extensions
             {
                 eventCreate.DataSetId = simulationEvent.DataSetId.Value;
             }
+            if (simulationEvent.ValidationEndOverwrite.HasValue)
+            {
+                eventCreate.Metadata.Add(SimulationEventMetadata.ValidationEndOverwriteKey, simulationEvent.ValidationEndOverwrite.ToString());
+            }
             return eventCreate;
         }
     }

--- a/Cognite.Simulator.Extensions/Types.cs
+++ b/Cognite.Simulator.Extensions/Types.cs
@@ -205,6 +205,12 @@ namespace Cognite.Simulator.Extensions
         /// External ID of the CDF file containing the simulation configuration
         /// </summary>
         public string CalculationId { get; set; }
+
+        /// <summary>
+        /// Typically, the connector samples data using the current time: time the event was picked for execution.
+        /// In case the data should be sampled from a time in the past, than this overwrite should be used.
+        /// </summary>
+        public long? ValidationEndOverwrite { get; set; }
     }
 
     /// <summary>

--- a/Cognite.Simulator.Tests/CdfTestClient.cs
+++ b/Cognite.Simulator.Tests/CdfTestClient.cs
@@ -12,9 +12,16 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Cognite.Simulator.Tests
 {
+    [CollectionDefinition(nameof(SequentialTestCollection), DisableParallelization = true)]
+    public class SequentialTestCollection
+    {
+
+    }
+
     internal static class CdfTestClient
     {
         internal const long TestDataset = 7900866844615420;

--- a/Cognite.Simulator.Tests/UtilsTests/CommonUtilsTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/CommonUtilsTest.cs
@@ -1,0 +1,99 @@
+﻿using Cognite.Extractor.Common;
+using Cognite.Simulator.Utils;
+using CogniteSdk;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Cognite.Simulator.Tests.UtilsTests
+{
+    public class CommonUtilsTest
+    {
+        [Theory]
+        [InlineData("60s", 1, 0, 0)]
+        [InlineData("12m", 12, 0, 0)]
+        [InlineData("240h", 0, 240, 0)]
+        [InlineData("2d", 0, 0, 2)]
+        [InlineData("1w", 0, 0, 7)]
+        public void TestParseStringToTimeSpan(string repeat, int min, int hours, int days)
+        {
+            var expected = new TimeSpan(days, hours, min, 0);
+            var result = SimulationUtils.ConfigurationTimeStringToTimeSpan(repeat);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1631296740000, 1631293140000, 1631296740000, true, true)]
+        [InlineData(1631274480000, 1631263860000, 1631267460000, true, true)]
+        [InlineData(1631278800000, 1631275200000, 1631278800000, true, false)]
+        [InlineData(1631274480000, 1631263860000, 1631267460000, false, true)]
+        [InlineData(1631271600000, 1631268000000, 1631271600000, false, false)]
+        public async Task TestRunSteadyStateAndLogicalCheck(
+            long validationEnd,
+            long expectedStart,
+            long expectedEnd,
+            bool runLogicCheck,
+            bool runSsdCheck)
+        {
+            var services = new ServiceCollection();
+            services.AddCogniteTestClient();
+
+            using var provider = services.BuildServiceProvider();
+            var cdf = provider.GetRequiredService<Client>();
+            var dataPoints = cdf.DataPoints;
+
+            var config = NewConfig();
+            config.LogicalCheck.Enabled = runLogicCheck;
+            config.SteadyStateDetection.Enabled = runSsdCheck;
+
+            var result = await SimulationUtils.RunSteadyStateAndLogicalCheck(
+                dataPoints,
+                config,
+                CogniteTime.FromUnixTimeMilliseconds(validationEnd),
+                System.Threading.CancellationToken.None).ConfigureAwait(false);
+
+            Assert.True(result.Min.HasValue);
+            Assert.Equal(expectedStart, result.Min.Value);
+            Assert.True(result.Max.HasValue);
+            Assert.Equal(expectedEnd, result.Max.Value);
+        }
+
+        private static SimulationConfigurationWithDataSampling NewConfig()
+        {
+            // Assumes a time series in CDF with the id SimConnect-IntegrationTests-OnOffValues and
+            // one with id SimConnect-IntegrationTests-SsdSensorData.
+            // The time stamps and values for these time series match the ones used in the DataProcessing
+            // library tests
+            return new()
+            {
+                DataSampling = new DataSamplingConfiguration
+                {
+                    Granularity = 1,
+                    SamplingWindow = 60,
+                    ValidationWindow = 1200
+                },
+                LogicalCheck = new LogicalCheckConfiguration
+                {
+                    Enabled = true,
+                    ExternalId = "SimConnect-IntegrationTests-OnOffValues",
+                    AggregateType = "stepInterpolation",
+                    Check = "eq",
+                    Value = 1.0
+                },
+                SteadyStateDetection = new SteadyStateDetectionConfiguration
+                {
+                    Enabled = true,
+                    ExternalId = "SimConnect-IntegrationTests-SsdSensorData",
+                    AggregateType = "average",
+                    MinSectionSize = 60,
+                    VarThreshold = 1.0,
+                    SlopeThreshold = -3.0
+                }
+            };
+        }
+    }
+}

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace Cognite.Simulator.Tests.UtilsTests
 {
+    [Collection(nameof(SequentialTestCollection))]
     public class ConnectorBaseTest
     {
         [Fact]

--- a/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace Cognite.Simulator.Tests.UtilsTests
 {
+    [Collection(nameof(SequentialTestCollection))]
     public class FileLibraryTest
     {
         [Fact]
@@ -22,7 +23,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
             services.AddHttpClient<FileDownloadClient>();
-            services.AddTransient<ModeLibraryTest>();
+            services.AddSingleton<ModeLibraryTest>();
             StateStoreConfig stateConfig = null;
 
             try
@@ -94,7 +95,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
             services.AddHttpClient<FileDownloadClient>();
-            services.AddTransient<ConfigurationLibraryTest>();
+            services.AddSingleton<ConfigurationLibraryTest>();
 
             StateStoreConfig stateConfig = null;
 
@@ -245,7 +246,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
     }
 
     public class ConfigurationLibraryTest :
-        ConfigurationLibraryBase<TestConfigurationState, FileStatePoco, SimulationConfigurationBase>
+        ConfigurationLibraryBase<TestConfigurationState, FileStatePoco, SimulationConfigurationWithDataSampling>
     {
         public ConfigurationLibraryTest(
             CogniteDestination cdf, 

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -90,7 +90,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 // Run the simulation runner and verify that the event above was picked up for execution
                 using var linkedTokenSource2 = CancellationTokenSource.CreateLinkedTokenSource(source.Token);
                 var linkedToken2 = linkedTokenSource2.Token;
-                linkedTokenSource2.CancelAfter(TimeSpan.FromMinutes(2));
+                linkedTokenSource2.CancelAfter(TimeSpan.FromSeconds(10));
                 var taskList2 = new List<Task> { runner.Run(linkedToken2) };
                 await taskList2.RunAll(linkedTokenSource2).ConfigureAwait(false);
 

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -1,0 +1,246 @@
+﻿using Cognite.Extractor.StateStorage;
+using Cognite.Extractor.Utils;
+using Cognite.Simulator.Extensions;
+using Cognite.Simulator.Utils;
+using CogniteSdk;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Cognite.Simulator.Tests.UtilsTests
+{
+    [Collection(nameof(SequentialTestCollection))]
+    public class SimulationRunnerTest
+    {
+        private const long validationEndOverwrite = 1631304000000L;
+
+        [Fact]
+        public async Task TestSimulationRunnerBase()
+        {
+            var services = new ServiceCollection();
+            services.AddCogniteTestClient();
+            services.AddHttpClient<FileDownloadClient>();
+            services.AddSingleton<ModeLibraryTest>();
+            services.AddSingleton<ConfigurationLibraryTest>();
+            services.AddSingleton<SampleSimulationRunner>();
+
+            StateStoreConfig stateConfig = null;
+
+            string eventId = "";
+            string sequenceId = "";
+
+            using var source = new CancellationTokenSource();
+            using var provider = services.BuildServiceProvider();
+            var cdf = provider.GetRequiredService<Client>();
+            try
+            {
+                stateConfig = provider.GetRequiredService<StateStoreConfig>();
+
+                var modelLib = provider.GetRequiredService<ModeLibraryTest>();
+                var configLib = provider.GetRequiredService<ConfigurationLibraryTest>();
+                var runner = provider.GetRequiredService<SampleSimulationRunner>();
+
+                // Run model and configuration libraries to fetch the test model and
+                // test simulation configuration from CDF
+                await modelLib.Init(source.Token).ConfigureAwait(false);
+                await configLib.Init(source.Token).ConfigureAwait(false);
+
+                using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(source.Token);
+                var linkedToken = linkedTokenSource.Token;
+                linkedTokenSource.CancelAfter(TimeSpan.FromSeconds(6));
+                var taskList = new List<Task>(modelLib.GetRunTasks(linkedToken));
+                taskList.AddRange(configLib.GetRunTasks(linkedToken));
+                await taskList.RunAll(linkedTokenSource).ConfigureAwait(false);
+
+                Assert.NotEmpty(configLib.State);
+                var configState = Assert.Contains(
+                    "PROSPER-SC-UserDefined-SRT-Connector_Test_Model", // This simulator configuration should exist in CDF
+                    (IReadOnlyDictionary<string, TestConfigurationState>)configLib.State);
+                var configObj = configLib.GetSimulationConfiguration(
+                    "PROSPER", "Connector Test Model", "UserDefined", "SRT");
+                Assert.NotNull(configObj);
+
+                // Create a simulation event ready to run for the test configuration
+                var events = await cdf.Events.CreateSimulationEventReadyToRun(
+                    new List<SimulationEvent> 
+                    { 
+                        new SimulationEvent
+                        {
+                            Calculation = configObj.Calculation,
+                            CalculationId = configState.Id,
+                            Connector = configObj.Connector,
+                            DataSetId = CdfTestClient.TestDataset,
+                            RunType = "manual",
+                            UserEmail = configObj.UserEmail,
+                            ValidationEndOverwrite = validationEndOverwrite
+                        }
+                    
+                    },
+                    source.Token).ConfigureAwait(false);
+                Assert.NotEmpty(events);
+                eventId = events.First().ExternalId;
+
+                // Run the simulation runner and verify that the event above was picked up for execution
+                using var linkedTokenSource2 = CancellationTokenSource.CreateLinkedTokenSource(source.Token);
+                var linkedToken2 = linkedTokenSource2.Token;
+                linkedTokenSource2.CancelAfter(TimeSpan.FromMinutes(2));
+                var taskList2 = new List<Task> { runner.Run(linkedToken2) };
+                await taskList2.RunAll(linkedTokenSource2).ConfigureAwait(false);
+
+                Assert.True(runner.MetadataInitialized);
+                Assert.True(runner.SimulationEventExecuted);
+
+                var eventUpdated = await cdf.Events.RetrieveAsync(
+                    new List<string> { eventId },
+                    true,
+                    source.Token).ConfigureAwait(false);
+                Assert.NotEmpty(eventUpdated);
+                var eventMetadata = eventUpdated.First().Metadata;
+                Assert.True(eventMetadata.ContainsKey("calcTime"));
+                Assert.True(long.TryParse(eventMetadata["calcTime"], out var eventCalcTime));
+                Assert.True(eventCalcTime <= validationEndOverwrite);
+                Assert.True(eventMetadata.TryGetValue("status", out var eventStatus));
+                Assert.Equal("success", eventStatus);
+                
+
+                // A sequence should have been created in CDF with the run configuration data
+                // and one with the simulation results (system curves).
+                Assert.True(eventMetadata.TryGetValue("runConfigurationSequence", out var runSequenceId));
+                Assert.True(eventMetadata.TryGetValue("runConfigurationRowStart", out var runSequenceRowStart));
+                Assert.True(eventMetadata.TryGetValue("runConfigurationRowEnd", out var runSequenceRowEnd));
+                sequenceId = runSequenceId;
+
+                // Verify a sequence was created in CDF with the run configuration
+                // Check sampling results
+                var data = await cdf.Sequences.ListRowsAsync(
+                    new SequenceRowQuery
+                    {
+                        ExternalId = runSequenceId,
+                        Start = long.Parse(runSequenceRowStart),
+                        End = long.Parse(runSequenceRowEnd) + 1
+                    },
+                    source.Token).ConfigureAwait(false);
+                var dictResult = ToRowDictionary(data);
+                Assert.True(dictResult.ContainsKey("runEventId"));
+                Assert.Equal(eventId, dictResult["runEventId"]);
+                Assert.True(dictResult.ContainsKey("calcTime"));
+                Assert.Equal(eventCalcTime.ToString(), dictResult["calcTime"]);
+
+                // Verify sampling start, end and calculation time values
+                Assert.True(dictResult.ContainsKey("samplingEnd"));
+                Assert.True(dictResult.ContainsKey("samplingStart"));
+                Assert.True(dictResult.ContainsKey("validationEndOffset"));
+
+                SamplingRange range = new TimeRange()
+                {
+                    Min = long.Parse(dictResult["samplingStart"]),
+                    Max = long.Parse(dictResult["samplingEnd"])
+                };
+                Assert.Equal(eventCalcTime, range.Midpoint);
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(eventId))
+                {
+                    await cdf.Events.DeleteAsync(
+                        new List<string> { eventId }, source.Token).ConfigureAwait(false);
+                }
+                if (!string.IsNullOrEmpty(sequenceId))
+                {
+                    await cdf.Sequences.DeleteAsync(
+                        new List<string> { sequenceId }, source.Token).ConfigureAwait(false);
+                }
+                provider.Dispose();
+                if (Directory.Exists("./files"))
+                {
+                    Directory.Delete("./files", true);
+                }
+                if (Directory.Exists("./configurations"))
+                {
+                    Directory.Delete("./configurations", true);
+                }
+                if (stateConfig != null)
+                {
+                    StateUtils.DeleteLocalFile(stateConfig.Location);
+                }
+            }
+
+        }
+
+        private static Dictionary<string, string> ToRowDictionary(SequenceData data)
+        {
+            Dictionary<string, string> result = new();
+            foreach (var row in data.Rows)
+            {
+                var cells = row.Values.ToArray();
+                var key = ((MultiValue.String)cells[0]).Value;
+                var value = ((MultiValue.String)cells[1]).Value;
+                result.Add(key, value);
+            }
+            return result;
+        }
+    }
+
+    public class SampleSimulationRunner :
+        SimulationRunnerBase<TestFileState, TestConfigurationState, SimulationConfigurationWithDataSampling>
+    {
+        private const string connectorName = "integration-tests-connector";
+        public bool MetadataInitialized { get; private set; }
+        public bool SimulationEventExecuted { get; private set; }
+
+        public SampleSimulationRunner(
+            CogniteDestination cdf,
+            ModeLibraryTest modelLibrary, 
+            ConfigurationLibraryTest configLibrary, 
+            ILogger<SampleSimulationRunner> logger) : 
+            base(
+                new ConnectorConfig
+                {
+                    NamePrefix = connectorName,
+                    AddMachineNameSuffix = false
+                },
+                new List<SimulatorConfig>
+                {
+                    new SimulatorConfig
+                    {
+                        Name = "PROSPER",
+                        DataSetId = CdfTestClient.TestDataset
+                    }
+                },
+                cdf, 
+                modelLibrary, 
+                configLibrary, 
+                logger)
+        {
+        }
+
+        protected override void InitSimulationEventMetadata(
+            TestFileState modelState, 
+            TestConfigurationState configState, 
+            SimulationConfigurationWithDataSampling configObj, 
+            Dictionary<string, string> metadata)
+        {
+            MetadataInitialized = true;
+        }
+
+        protected override Task RunSimulation(
+            Event e, 
+            DateTime startTime, 
+            TestFileState modelState, 
+            TestConfigurationState configState, 
+            SimulationConfigurationWithDataSampling configObj, 
+            SamplingRange samplingRange, 
+            CancellationToken token)
+        {
+            SimulationEventExecuted = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -90,7 +90,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 // Run the simulation runner and verify that the event above was picked up for execution
                 using var linkedTokenSource2 = CancellationTokenSource.CreateLinkedTokenSource(source.Token);
                 var linkedToken2 = linkedTokenSource2.Token;
-                linkedTokenSource2.CancelAfter(TimeSpan.FromSeconds(10));
+                linkedTokenSource2.CancelAfter(TimeSpan.FromSeconds(15));
                 var taskList2 = new List<Task> { runner.Run(linkedToken2) };
                 await taskList2.RunAll(linkedTokenSource2).ConfigureAwait(false);
 
@@ -157,7 +157,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     await cdf.Sequences.DeleteAsync(
                         new List<string> { sequenceId }, source.Token).ConfigureAwait(false);
                 }
-                provider.Dispose();
+                provider.Dispose(); // Dispose provider to also dispose managed services
                 if (Directory.Exists("./files"))
                 {
                     Directory.Delete("./files", true);
@@ -239,6 +239,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
             SamplingRange samplingRange, 
             CancellationToken token)
         {
+            // Real connectors should implement the actual simulation run here
+            // and save the results back to CDF
             SimulationEventExecuted = true;
             return Task.CompletedTask;
         }

--- a/Cognite.Simulator.Utils/Cognite.Simulator.Utils.csproj
+++ b/Cognite.Simulator.Utils/Cognite.Simulator.Utils.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Cognite.DataProcessing\Cognite.DataProcessing.csproj" />
     <ProjectReference Include="..\Cognite.Simulator.Extensions\Cognite.Simulator.Extensions.csproj" />
   </ItemGroup>
 

--- a/Cognite.Simulator.Utils/CommonUtils.cs
+++ b/Cognite.Simulator.Utils/CommonUtils.cs
@@ -54,6 +54,9 @@ namespace Cognite.Simulator.Utils
         }
     }
 
+    /// <summary>
+    /// Collects utility methods used by the connector
+    /// </summary>
     public static class SimulationUtils
     {
         /// <summary>
@@ -91,8 +94,9 @@ namespace Cognite.Simulator.Utils
         }
 
         /// <summary>
-        /// Run logical check (well status) and steady state detection based on a simulation configuration. 
+        /// Run logical check and steady state detection based on a simulation configuration. 
         /// </summary>
+        /// <param name="dataPoints">CDF data points resource</param>
         /// <param name="config">Simulation configuration</param>
         /// <param name="validationEnd">Time of the end of the validation check</param>
         /// <param name="token">Cancellation token</param>
@@ -103,6 +107,10 @@ namespace Cognite.Simulator.Utils
             DateTime validationEnd,
             CancellationToken token)
         {
+            if (config == null || config.DataSampling == null)
+            {
+                throw new SimulationException("Data sampling configuration is missing");
+            }
             var validationStart = validationEnd - TimeSpan.FromMinutes(config.DataSampling.ValidationWindow);
             var validationRange = new TimeRange
             {
@@ -191,6 +199,14 @@ namespace Cognite.Simulator.Utils
             return DataSampling.LogicalCheck(ts, lcConfig.Value, op, validationRange.Max);
         }
 
+        /// <summary>
+        /// Convert data points sampled from CDF to time series data used by
+        /// the <see cref="DataProcessing"/> library
+        /// </summary>
+        /// <param name="dataPoints">Input data points</param>
+        /// <param name="granularity">Granularity in minutes</param>
+        /// <param name="aggreagate">CDF aggregate type</param>
+        /// <returns>Time series data</returns>
         public static TimeSeriesData ToTimeSeriesData(
             this (long[] Timestamps, double[] Values) dataPoints,
             int granularity,

--- a/Cognite.Simulator.Utils/CommonUtils.cs
+++ b/Cognite.Simulator.Utils/CommonUtils.cs
@@ -1,8 +1,15 @@
-﻿using System;
+﻿using Cognite.DataProcessing;
+using Cognite.Extractor.Common;
+using Cognite.Simulator.Extensions;
+using CogniteSdk;
+using CogniteSdk.Resources;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using TimeRange = CogniteSdk.TimeRange;
 
 namespace Cognite.Simulator.Utils
 {
@@ -45,5 +52,156 @@ namespace Cognite.Simulator.Utils
                 throw ex;
             }
         }
+    }
+
+    public static class SimulationUtils
+    {
+        /// <summary>
+        /// Parses strings in the format <c>number(w|d|h|m|s)</c> to a <see cref="TimeSpan"/>
+        /// object
+        /// </summary>
+        /// <param name="time">Time string</param>
+        public static TimeSpan ConfigurationTimeStringToTimeSpan(string time)
+        {
+            var repeatRegex = Regex.Match(
+                time,
+                @"((?<weeks>\d+)w)|((?<days>\d+)d)|((?<hours>\d+)h)|((?<minutes>\d+)m)|((?<seconds>\d+)s)", RegexOptions.Compiled);
+            if (repeatRegex.Groups["weeks"].Success)
+            {
+                var hours = int.Parse(repeatRegex.Groups["weeks"].Value) * 168;
+                return TimeSpan.FromHours(hours);
+            }
+            if (repeatRegex.Groups["days"].Success)
+            {
+                return TimeSpan.FromDays(int.Parse(repeatRegex.Groups["days"].Value));
+            }
+            if (repeatRegex.Groups["hours"].Success)
+            {
+                return TimeSpan.FromHours(int.Parse(repeatRegex.Groups["hours"].Value));
+            }
+            if (repeatRegex.Groups["minutes"].Success)
+            {
+                return TimeSpan.FromMinutes(int.Parse(repeatRegex.Groups["minutes"].Value));
+            }
+            if (repeatRegex.Groups["seconds"].Success)
+            {
+                return TimeSpan.FromSeconds(int.Parse(repeatRegex.Groups["seconds"].Value));
+            }
+            throw new ArgumentException("Cannot parse provided string to a TimeSpan", nameof(time));
+        }
+
+        /// <summary>
+        /// Run logical check (well status) and steady state detection based on a simulation configuration. 
+        /// </summary>
+        /// <param name="config">Simulation configuration</param>
+        /// <param name="validationEnd">Time of the end of the validation check</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns></returns>
+        public static async Task<TimeRange> RunSteadyStateAndLogicalCheck(
+            DataPointsResource dataPoints,
+            SimulationConfigurationWithDataSampling config,
+            DateTime validationEnd,
+            CancellationToken token)
+        {
+            var validationStart = validationEnd - TimeSpan.FromMinutes(config.DataSampling.ValidationWindow);
+            var validationRange = new TimeRange
+            {
+                Min = validationStart.ToUnixTimeMilliseconds(),
+                Max = validationEnd.ToUnixTimeMilliseconds()
+            };
+
+            // Check for sensor status, if enabled
+            TimeSeriesData validationDps = null;
+            if (config.LogicalCheck != null && config.LogicalCheck.Enabled)
+            {
+                var dps = await dataPoints.GetSample(
+                    config.LogicalCheck.ExternalId,
+                    config.LogicalCheck.AggregateType.ToDataPointAggregate(),
+                    config.DataSampling.Granularity,
+                    validationRange,
+                    token).ConfigureAwait(false);
+                validationDps = dps.ToTimeSeriesData(
+                    config.DataSampling.Granularity,
+                    config.LogicalCheck.AggregateType.ToDataPointAggregate());
+                validationDps = LogicalCheckInternal(validationDps, validationRange, config.LogicalCheck, config.DataSampling);
+            }
+
+            // Check for steady state, if enabled
+            TimeSeriesData ssdMap = null;
+            if (config.SteadyStateDetection != null && config.SteadyStateDetection.Enabled)
+            {
+                var ssDps = await dataPoints.GetSample(
+                    config.SteadyStateDetection.ExternalId,
+                    config.SteadyStateDetection.AggregateType.ToDataPointAggregate(),
+                    config.DataSampling.Granularity,
+                    validationRange,
+                    token).ConfigureAwait(false);
+
+                ssdMap = Detectors.SteadyStateDetector(
+                    ssDps.ToTimeSeriesData(
+                        config.DataSampling.Granularity,
+                        config.SteadyStateDetection.AggregateType.ToDataPointAggregate()),
+                    config.SteadyStateDetection.MinSectionSize,
+                    config.SteadyStateDetection.VarThreshold,
+                    config.SteadyStateDetection.SlopeThreshold);
+            }
+
+            TimeSeriesData feasibleTimestamps;
+            if (validationDps == null)
+            {
+                feasibleTimestamps = ssdMap;
+            }
+            else if (ssdMap == null)
+            {
+                feasibleTimestamps = validationDps;
+            }
+            else
+            {
+                // Find union between well status and steady state
+                feasibleTimestamps = DataSampling.UnionLogicTimeSeries(validationDps, ssdMap);
+            }
+
+            // Find sampling start/end
+            var samplingEnd = validationRange.Max;
+            var samplingWindowMs = (long)TimeSpan.FromMinutes(config.DataSampling.SamplingWindow).TotalMilliseconds;
+            if (feasibleTimestamps != null)
+            {
+                samplingEnd = DataSampling.FindSamplingTime(feasibleTimestamps, samplingWindowMs);
+                if (!samplingEnd.HasValue)
+                {
+                    throw new SimulationException("Could not find a timestamp that can be used to sample process data under steady state");
+                }
+            }
+
+            var samplingStart = samplingEnd - samplingWindowMs;
+            return new TimeRange
+            {
+                Min = samplingStart,
+                Max = samplingEnd
+            };
+        }
+
+        private static TimeSeriesData LogicalCheckInternal(TimeSeriesData ts, TimeRange validationRange, LogicalCheckConfiguration lcConfig, DataSamplingConfiguration sampling)
+        {
+            if (!Enum.TryParse(lcConfig.Check, true, out DataSampling.LogicOperator op))
+            {
+                throw new ArgumentException($"Logical check operator not recognized: {lcConfig.Check}", nameof(lcConfig));
+            }
+
+            return DataSampling.LogicalCheck(ts, lcConfig.Value, op, validationRange.Max);
+        }
+
+        public static TimeSeriesData ToTimeSeriesData(
+            this (long[] Timestamps, double[] Values) dataPoints,
+            int granularity,
+            Extensions.DataPointAggregate aggreagate)
+        {
+            return new TimeSeriesData(
+                dataPoints.Timestamps,
+                dataPoints.Values,
+                granularity * 60_000,
+                aggreagate == Extensions.DataPointAggregate.StepInterpolation);
+        }
+
     }
 }

--- a/Cognite.Simulator.Utils/Configuration.cs
+++ b/Cognite.Simulator.Utils/Configuration.cs
@@ -59,4 +59,47 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         public string FilesDirectory { get; set; }
     }
+
+    public class ConnectorConfig
+    {
+        public string NamePrefix { get; set; }
+
+        /// <summary>
+        /// If true, the connector name is composed of the prefix <see cref="NamePrefix"/> and
+        /// the name of the machine running the connector
+        /// </summary>
+        public bool AddMachineNameSuffix { get; set; } = true;
+
+        /// <summary>
+        /// The connector will update its heartbeat in CDF with this interval (in seconds)
+        /// </summary>
+        public int StatusInterval { get; set; } = 10;
+
+        /// <summary>
+        /// The connector will fetch simulation calculation events from CDF with this interval (in seconds)
+        /// </summary>
+        public int FetchEventsInterval { get; set; } = 5;
+
+        /// <summary>
+        /// The connector will run simulation events found on CDF that are not older than
+        /// this value (in seconds). In case it finds events older than this, the events will
+        /// fail due to timeout
+        /// </summary>
+        public int SimulationEventTolerance { get; set; } = 1800; // 30 min
+
+        /// <summary>
+        /// The maximum number of rows to insert into a single sequence in CDF
+        /// </summary>
+        public long MaximumNumberOfSequenceRows { get; set; } = 100_000;
+
+        public string GetConnectorName()
+        {
+            if (!AddMachineNameSuffix)
+            {
+                return NamePrefix;
+            }
+            return $"{NamePrefix}{Environment.MachineName}";
+        }
+    }
+
 }

--- a/Cognite.Simulator.Utils/Configuration.cs
+++ b/Cognite.Simulator.Utils/Configuration.cs
@@ -60,8 +60,17 @@ namespace Cognite.Simulator.Utils
         public string FilesDirectory { get; set; }
     }
 
+    /// <summary>
+    /// Represents the configuration for connectors. This defines basic
+    /// connector properties such as name and intervals for status report and
+    /// for fetching events
+    /// </summary>
     public class ConnectorConfig
     {
+        /// <summary>
+        /// The connector name prefix. If <see cref="AddMachineNameSuffix"/> is set to <c>false</c>
+        /// then this is the connector name
+        /// </summary>
         public string NamePrefix { get; set; }
 
         /// <summary>
@@ -92,6 +101,10 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         public long MaximumNumberOfSequenceRows { get; set; } = 100_000;
 
+        /// <summary>
+        /// Returns the connector name, composed of the configured prefix and suffix
+        /// </summary>
+        /// <returns>Connector name</returns>
         public string GetConnectorName()
         {
             if (!AddMachineNameSuffix)

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -19,7 +19,7 @@ namespace Cognite.Simulator.Utils
     /// </summary>
     /// <typeparam name="T">Type of the state object used in this library</typeparam>
     /// <typeparam name="U">Type of the data object used to serialize and deserialize state</typeparam>
-    public abstract class ModelLibraryBase<T, U> : FileLibrary<T, U>
+    public abstract class ModelLibraryBase<T, U> : FileLibrary<T, U>, IModelProvider<T>
         where T : ModelStateBase
         where U : ModelStateBasePoco
     {
@@ -65,7 +65,7 @@ namespace Cognite.Simulator.Utils
         /// <param name="simulator">Simulator name</param>
         /// <param name="modelName">Model name</param>
         /// <returns></returns>
-        protected IEnumerable<T> GetAllModelVersions(string simulator, string modelName)
+        public IEnumerable<T> GetAllModelVersions(string simulator, string modelName)
         {
             var modelVersions = State.Values
                 .Where(s => s.ModelName == modelName
@@ -187,6 +187,12 @@ namespace Cognite.Simulator.Utils
         protected abstract Task ExtractModelInformation(
             IEnumerable<T> modelStates,
             CancellationToken token);
+    }
+
+    public interface IModelProvider<T>
+    {
+        T GetLatestModelVersion(string simulator, string modelName);
+        IEnumerable<T> GetAllModelVersions(string simulator, string modelName);
     }
 
     /// <summary>

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -43,12 +43,7 @@ namespace Cognite.Simulator.Utils
         {
         }
 
-        /// <summary>
-        /// Returns the state object of the latest version of the given model
-        /// </summary>
-        /// <param name="simulator">Simulator name</param>
-        /// <param name="modelName">Model name</param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public T GetLatestModelVersion(string simulator, string modelName)
         {
             var modelVersions = GetAllModelVersions(simulator, modelName);
@@ -59,12 +54,7 @@ namespace Cognite.Simulator.Utils
             return null;
         }
 
-        /// <summary>
-        /// Returns the state objects of all the versions of the given model
-        /// </summary>
-        /// <param name="simulator">Simulator name</param>
-        /// <param name="modelName">Model name</param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public IEnumerable<T> GetAllModelVersions(string simulator, string modelName)
         {
             var modelVersions = State.Values
@@ -189,9 +179,26 @@ namespace Cognite.Simulator.Utils
             CancellationToken token);
     }
 
+    /// <summary>
+    /// Interface for libraries that can provide model information
+    /// </summary>
+    /// <typeparam name="T">Model state type</typeparam>
     public interface IModelProvider<T>
     {
+        /// <summary>
+        /// Returns the state object of the latest version of the given model
+        /// </summary>
+        /// <param name="simulator">Simulator</param>
+        /// <param name="modelName">Model Name</param>
+        /// <returns>State object</returns>
         T GetLatestModelVersion(string simulator, string modelName);
+
+        /// <summary>
+        /// Returns the state objects of all the versions of the given model
+        /// </summary>
+        /// <param name="simulator">Simulator name</param>
+        /// <param name="modelName">Model name</param>
+        /// <returns>List of state objects</returns>
         IEnumerable<T> GetAllModelVersions(string simulator, string modelName);
     }
 

--- a/Cognite.Simulator.Utils/SimulationRunnerBase.cs
+++ b/Cognite.Simulator.Utils/SimulationRunnerBase.cs
@@ -208,6 +208,10 @@ namespace Cognite.Simulator.Utils
             var validationEnd = startTime;
             try
             {
+                if (configObj.DataSampling == null)
+                {
+                    throw new SimulationException($"Data sampling configuration for {configObj.CalculationName} missing");
+                }
                 // Determine the validation end time
                 if (e.Metadata.TryGetValue(SimulationEventMetadata.ValidationEndOverwriteKey, out string validationEndOverwrite)
                     && long.TryParse(validationEndOverwrite, out long overwriteValue))
@@ -310,6 +314,9 @@ namespace Cognite.Simulator.Utils
             {
                 throw new ArgumentNullException(nameof(configState));
             }
+
+            _logger.LogDebug("Storing run configuration in CDF");
+
             // Create a dictionary with the run details
             var runDetails = new Dictionary<string, string>
             {
@@ -337,8 +344,9 @@ namespace Cognite.Simulator.Utils
             runDetails.Add("samplingGranularity", configObj.DataSampling.Granularity.ToString());
 
             // Logical check details
-            runDetails.Add("logicalCheckEnabled", configObj.LogicalCheck.Enabled.ToString());
-            if (configObj.LogicalCheck.Enabled)
+            bool logicalCheckEnabled = configObj.LogicalCheck != null && configObj.LogicalCheck.Enabled;
+            runDetails.Add("logicalCheckEnabled", logicalCheckEnabled.ToString());
+            if (logicalCheckEnabled)
             {
                 runDetails.Add("logicalCheckTimeSeries", configObj.LogicalCheck.ExternalId);
                 runDetails.Add("logicalCheckSamplingMethod", configObj.LogicalCheck.AggregateType);
@@ -347,8 +355,9 @@ namespace Cognite.Simulator.Utils
             }
 
             // Steady state details
-            runDetails.Add("ssdEnabled", configObj.SteadyStateDetection.Enabled.ToString());
-            if (configObj.SteadyStateDetection.Enabled)
+            bool ssdEnabled = configObj.SteadyStateDetection != null && configObj.SteadyStateDetection.Enabled;
+            runDetails.Add("ssdEnabled", ssdEnabled.ToString());
+            if (ssdEnabled)
             {
                 runDetails.Add("ssdTimeSeries", configObj.SteadyStateDetection.ExternalId);
                 runDetails.Add("ssdSamplingMethod", configObj.SteadyStateDetection.AggregateType);

--- a/Cognite.Simulator.Utils/SimulationRunnerBase.cs
+++ b/Cognite.Simulator.Utils/SimulationRunnerBase.cs
@@ -1,0 +1,447 @@
+﻿using Cognite.Extensions;
+using Cognite.Extractor.Common;
+using Cognite.Extractor.Utils;
+using Cognite.Simulator.Extensions;
+using CogniteSdk;
+using CogniteSdk.Resources;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.Simulator.Utils
+{
+    public abstract class SimulationRunnerBase<T, U, V>
+        where T : ModelStateBase
+        where U : ConfigurationStateBase
+        where V : SimulationConfigurationWithDataSampling
+    {
+        private readonly ConnectorConfig _connectorConfig;
+        private readonly IList<SimulatorConfig> _simulators;
+        private readonly EventsResource _cdfEvents;
+        private readonly SequencesResource _cdfSequences;
+        private readonly DataPointsResource _cdfDataPoints;
+        private readonly ILogger _logger;
+        private readonly IModelProvider<T> _modelLib;
+        private readonly IConfigurationProvider<U, V> _configLib;
+
+        public SimulationRunnerBase(
+            ConnectorConfig connectorConfig,
+            IList<SimulatorConfig> simulators,
+            CogniteDestination cdf,
+            IModelProvider<T> modelLibrary,
+            IConfigurationProvider<U, V> configLibrary,
+            ILogger logger)
+        {
+            _connectorConfig = connectorConfig;
+            _simulators = simulators;
+            _cdfEvents = cdf.CogniteClient.Events;
+            _cdfSequences = cdf.CogniteClient.Sequences;
+            _cdfDataPoints = cdf.CogniteClient.DataPoints;
+            _logger = logger;
+            _modelLib = modelLibrary;
+            _configLib = configLibrary;
+        }
+
+        public async Task Run(CancellationToken token)
+        {
+            var interval = TimeSpan.FromSeconds(_connectorConfig.FetchEventsInterval);
+            while (!token.IsCancellationRequested)
+            {
+                var simulators = _simulators.ToDictionary(s => s.Name, s => s.DataSetId);
+                // Find events that are ready to run
+                var simulationEvents = await _cdfEvents.FindSimulationEventsReadyToRun(
+                    simulators,
+                    _connectorConfig.GetConnectorName(),
+                    token).ConfigureAwait(false);
+                if (simulationEvents.Any())
+                {
+                    _logger.LogInformation(
+                        "{Number} simulation event(s) ready to run found in CDF",
+                        simulationEvents.Count());
+                }
+
+                // Find events that are running. Should not have any, as the connector runs events in sequence.
+                // Any running events indicates that the connector went down during the run, and the event should fail
+                var simulationRunningEvents = await _cdfEvents.FindSimulationEventsRunning(
+                    simulators,
+                    _connectorConfig.GetConnectorName(),
+                    token).ConfigureAwait(false);
+                if (simulationRunningEvents.Any())
+                {
+                    _logger.LogWarning(
+                        "{Number} simulation event(s) that are running (but should have finished) found in CDF",
+                        simulationRunningEvents.Count());
+                }
+                var allEvents = new List<Event>(simulationEvents);
+                allEvents.AddRange(simulationRunningEvents);
+
+                foreach (Event e in allEvents)
+                {
+                    var startTime = DateTime.UtcNow;
+                    try
+                    {
+                        if (e.Metadata[SimulationEventMetadata.StatusKey] == SimulationEventStatusValues.Running)
+                        {
+                            throw new ConnectorException("Calculation failed due to connector error");
+                        }
+                        var eventAge = startTime - CogniteTime.FromUnixTimeMilliseconds(e.LastUpdatedTime);
+                        if (eventAge >= TimeSpan.FromSeconds(_connectorConfig.SimulationEventTolerance))
+                        {
+                            throw new TimeoutException("Timeout: The connector could not run the calculation on time");
+                        }
+                        var (modelState, calcState, calcObj) = ValidateEventMetadata(e);
+                        var metadata = new Dictionary<string, string>();
+                        InitSimulationEventMetadata(
+                            modelState,
+                            calcState,
+                            calcObj,
+                            metadata);
+                        await InitSimulationRun(
+                            e, 
+                            startTime, 
+                            modelState, 
+                            calcState, 
+                            calcObj,
+                            metadata,
+                            token)
+                            .ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is ConnectorException ce && ce.Errors != null)
+                        {
+                            foreach (var error in ce.Errors)
+                            {
+                                _logger.LogError(error.Message);
+                            }
+                        }
+                        _logger.LogError("Calculation run failed with error: {Message}", ex.Message);
+                        await _cdfEvents.UpdateSimulationEventToFailure(
+                            e.ExternalId,
+                            startTime,
+                            null,
+                            ex.Message.LimitUtf8ByteCount(Sanitation.EventMetadataMaxPerValue),
+                            token).ConfigureAwait(false);
+                    }
+                }
+
+                await Task.Delay(interval, token).ConfigureAwait(false);
+            }
+        }
+
+        private (T, U, V) ValidateEventMetadata(Event e)
+        {
+            // Check for the needed files before start, fail the run if anything missing
+            if (!e.Metadata.TryGetValue(ModelMetadata.NameKey, out string modelName))
+            {
+                _logger.LogError("Event {Id} does not indicate the model name to use", e.ExternalId);
+                throw new SimulationException("Model name missing");
+            }
+            if (!e.Metadata.TryGetValue(CalculationMetadata.TypeKey, out string calcType))
+            {
+                _logger.LogError("Event {Id} does not indicate the calculation type to use", e.ExternalId);
+                throw new SimulationException("Calculation type missing");
+            }
+            string calcTypeUserDefined = null;
+            if (calcType == "UserDefined" && !e.Metadata.TryGetValue(CalculationMetadata.UserDefinedTypeKey, out calcTypeUserDefined))
+            {
+                _logger.LogError("Event {Id} is user-defined, but is missing the calculation type property", e.ExternalId);
+                throw new SimulationException("Type of user-defined calculation missing");
+            }
+            if (!e.Metadata.TryGetValue(BaseMetadata.SimulatorKey, out string simulator))
+            {
+                _logger.LogError("Event {Id} does not indicate the simulator to use", e.ExternalId);
+                throw new SimulationException("Simulator missing");
+            }
+            var model = _modelLib.GetLatestModelVersion(simulator, modelName);
+            if (model == null)
+            {
+                _logger.LogError("Could not find a local model file to run Event {Id}", e.ExternalId);
+                throw new SimulationException($"Could not find a model file for {modelName}");
+            }
+            var calcConfig = _configLib.GetSimulationConfiguration(simulator, modelName, calcType, calcTypeUserDefined);
+            var calcState = _configLib.GetSimulationConfigurationState(simulator, modelName, calcType, calcTypeUserDefined);
+            if (calcConfig == null || calcState == null)
+            {
+                _logger.LogError("Could not find a local configuration to run Event {Id}", e.ExternalId);
+                throw new SimulationException($"Could not find a simulation configuration for {modelName}");
+            }
+            return (model, calcState, calcConfig);
+        }
+
+        /// <summary>
+        /// Before running the simulation, the CDF Event that triggered it is changed from
+        /// <see cref="SimulationEventStatusValues.Ready"/> to <see cref="SimulationEventStatusValues.Running"/>.
+        /// At this point, any simulator specific metadata that needs to be added to the event, should be initialized here.
+        /// </summary>
+        /// <param name="modelState">Model state</param>
+        /// <param name="configState">Simulation configuration state</param>
+        /// <param name="configObj">Simulation configuration object</param>
+        /// <param name="metadata">Metadata to be added to the CDF event</param>
+        protected abstract void InitSimulationEventMetadata(
+            T modelState,
+            U configState,
+            V configObj,
+            Dictionary<string, string> metadata);
+
+        protected virtual async Task InitSimulationRun(
+            Event e,
+            DateTime startTime,
+            T modelState,
+            U configState,
+            V configObj,
+            Dictionary<string, string> metadata,
+            CancellationToken token)
+        {
+            await _cdfEvents.UpdateSimulationEventToRunning(
+                e.ExternalId,
+                startTime,
+                metadata,
+                modelState.Version,
+                token).ConfigureAwait(false);
+
+            SamplingRange samplingRange = null;
+            var validationEnd = startTime;
+            try
+            {
+                // Determine the validation end time
+                if (e.Metadata.TryGetValue(SimulationEventMetadata.ValidationEndOverwriteKey, out string validationEndOverwrite)
+                    && long.TryParse(validationEndOverwrite, out long overwriteValue))
+                {
+                    // If the event contains a validation end overwrite, use that instead of
+                    // the current time
+                    validationEnd = CogniteTime.FromUnixTimeMilliseconds(overwriteValue);
+                }
+                else
+                {
+                    // If the validation end time should be in the past, subtract the 
+                    // configured offset
+                    var offset = SimulationUtils.ConfigurationTimeStringToTimeSpan(
+                        configObj.DataSampling.ValidationEndOffset);
+                    validationEnd = startTime - offset;
+                }
+
+                // Find the sampling configuration results
+                samplingRange = await SimulationUtils.RunSteadyStateAndLogicalCheck(
+                    _cdfDataPoints,
+                    configObj,
+                    validationEnd,
+                    token).ConfigureAwait(false);
+
+                _logger.LogInformation("Running calculation {Type} for model {ModelName}. Calculation time: {Time}",
+                    configObj.CalculationType,
+                    configObj.ModelName,
+                    CogniteTime.FromUnixTimeMilliseconds(samplingRange.Midpoint));
+            }
+            catch (SimulationException ex)
+            {
+                _logger.LogError("Logical check or steady state detection failed: {Message}", ex.Message);
+                throw;
+            }
+            finally
+            {
+                // Save run configuration
+                await StoreRunConfigurationInCdf(
+                    samplingRange,
+                    modelState,
+                    configState,
+                    configObj,
+                    e,
+                    startTime,
+                    validationEnd,
+                    token).ConfigureAwait(false);
+            }
+
+            // Run the calculation
+            await RunSimulation(
+                e,
+                startTime,
+                modelState,
+                configState,
+                configObj, 
+                samplingRange, 
+                token).ConfigureAwait(false);
+
+            // Update event with success status
+            await _cdfEvents.UpdateSimulationEventToSuccess(
+                e.ExternalId,
+                startTime,
+                null,
+                "Calculation ran to completion",
+                token).ConfigureAwait(false);
+        }
+
+        protected abstract Task RunSimulation(
+            Event e, 
+            DateTime startTime,
+            T modelState,
+            U configState,
+            V configObj,
+            SamplingRange samplingRange,
+            CancellationToken token);
+
+        protected virtual async Task StoreRunConfigurationInCdf(
+            SamplingRange samplingRange,
+            T modelState,
+            U configState,
+            V configObj,
+            Event runEvent,
+            DateTime eventStartTime,
+            DateTime validationEnd,
+            CancellationToken token)
+        {
+            if (runEvent == null)
+            {
+                throw new ArgumentNullException(nameof(runEvent));
+            }
+            if (modelState == null)
+            {
+                throw new ArgumentNullException(nameof(modelState));
+            }
+            if (configObj == null)
+            {
+                throw new ArgumentNullException(nameof(configObj));
+            }
+            if (configState == null)
+            {
+                throw new ArgumentNullException(nameof(configState));
+            }
+            // Create a dictionary with the run details
+            var runDetails = new Dictionary<string, string>
+            {
+                { "runEventId", runEvent.ExternalId }
+            };
+            if (samplingRange != null)
+            {
+                runDetails.Add("calcTime", samplingRange.Midpoint.ToString());
+            }
+            runDetails.Add("modelVersion", modelState.Version.ToString());
+
+            // Validation range details
+            runDetails.Add("validationWindow", configObj.DataSampling.ValidationWindow.ToString());
+            runDetails.Add("validationStart", validationEnd.AddMinutes(-configObj.DataSampling.ValidationWindow).ToUnixTimeMilliseconds().ToString());
+            runDetails.Add("validationEnd", validationEnd.ToUnixTimeMilliseconds().ToString());
+            runDetails.Add("validationEndOffset", configObj.DataSampling.ValidationEndOffset);
+
+            // Sampling range details
+            runDetails.Add("samplingWindow", configObj.DataSampling.SamplingWindow.ToString());
+            if (samplingRange != null)
+            {
+                runDetails.Add("samplingStart", samplingRange.Start.Value.ToString());
+                runDetails.Add("samplingEnd", samplingRange.End.Value.ToString());
+            }
+            runDetails.Add("samplingGranularity", configObj.DataSampling.Granularity.ToString());
+
+            // Logical check details
+            runDetails.Add("logicalCheckEnabled", configObj.LogicalCheck.Enabled.ToString());
+            if (configObj.LogicalCheck.Enabled)
+            {
+                runDetails.Add("logicalCheckTimeSeries", configObj.LogicalCheck.ExternalId);
+                runDetails.Add("logicalCheckSamplingMethod", configObj.LogicalCheck.AggregateType);
+                runDetails.Add("logicalCheckOperation", configObj.LogicalCheck.Check);
+                runDetails.Add("logicalCheckThresholdValue", configObj.LogicalCheck.Value.ToString());
+            }
+
+            // Steady state details
+            runDetails.Add("ssdEnabled", configObj.SteadyStateDetection.Enabled.ToString());
+            if (configObj.SteadyStateDetection.Enabled)
+            {
+                runDetails.Add("ssdTimeSeries", configObj.SteadyStateDetection.ExternalId);
+                runDetails.Add("ssdSamplingMethod", configObj.SteadyStateDetection.AggregateType);
+                runDetails.Add("ssdMinSectionSize", configObj.SteadyStateDetection.MinSectionSize.ToString());
+                runDetails.Add("ssdVarThreshold", configObj.SteadyStateDetection.VarThreshold.ToString());
+                runDetails.Add("ssdSlopeThreshold", configObj.SteadyStateDetection.SlopeThreshold.ToString());
+            }
+
+            // Input time series details
+            foreach (var input in configObj.InputTimeSeries)
+            {
+                runDetails.Add($"inputTimeSeries{input.Type}", input.SensorExternalId);
+                runDetails.Add($"inputSamplingMethod{input.Type}", input.AggregateType);
+            }
+            // Determine what is the sequence id and the row number to start inserting data
+            var sequenceId = configState.RunDataSequence;
+            long rowStart = 0;
+            if (sequenceId != null)
+            {
+                rowStart = configState.RunSequenceLastRow + 1;
+
+                // Create a new sequence if reached the configured row limit
+                if (runDetails.Count + rowStart > _connectorConfig.MaximumNumberOfSequenceRows)
+                {
+                    sequenceId = null;
+                    rowStart = 0;
+                }
+            }
+            var calculation = new SimulatorCalculation
+            {
+                Model = new SimulatorModel
+                {
+                    Name = modelState.ModelName,
+                    Simulator = configObj.Simulator
+                },
+                Name = configObj.CalculationName,
+                Type = configObj.CalculationType,
+                UserDefinedType = configObj.CalcTypeUserDefined
+            };
+
+            // Update the local state with the sequence ID and the last row number
+            configState.RunDataSequence = sequenceId;
+            configState.RunSequenceLastRow = runDetails.Count + rowStart - 1;
+            await _configLib.StoreLibraryState(token).ConfigureAwait(false);
+
+            // Make sure the sequence exists in CDF
+            try
+            {
+                var seq = await _cdfSequences.StoreRunConfiguration(
+                    sequenceId,
+                    rowStart,
+                    runEvent.DataSetId,
+                    calculation,
+                    runDetails,
+                    token).ConfigureAwait(false);
+
+                // Update the event with calculation time and run details sequence
+                Dictionary<string, string> eventMetaData = new Dictionary<string, string>()
+                {
+                    { "runConfigurationSequence", seq.ExternalId },
+                    { "runConfigurationRowStart", rowStart.ToString() },
+                    { "runConfigurationRowEnd", configState.RunSequenceLastRow.ToString() }
+                };
+                if (samplingRange != null)
+                {
+                    eventMetaData.Add("calcTime", samplingRange.Midpoint.ToString());
+                }
+                await _cdfEvents.UpdateSimulationEvent(
+                    runEvent.ExternalId,
+                    eventStartTime,
+                    eventMetaData,
+                    token).ConfigureAwait(false);
+            }
+            catch (SimulationRunConfigurationException e)
+            {
+                throw new ConnectorException(e.Message, e.CogniteErrors);
+            }
+        }
+    }
+
+    public class SimulationException : Exception
+    {
+        public SimulationException()
+        {
+        }
+
+        public SimulationException(string message) : base(message)
+        {
+        }
+
+        public SimulationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+
+}

--- a/Cognite.Simulator.Utils/SimulationRunnerBase.cs
+++ b/Cognite.Simulator.Utils/SimulationRunnerBase.cs
@@ -260,7 +260,7 @@ namespace Cognite.Simulator.Utils
                     token).ConfigureAwait(false);
             }
 
-            // Run the calculation
+            // Run the simulation
             await RunSimulation(
                 e,
                 startTime,
@@ -386,18 +386,7 @@ namespace Cognite.Simulator.Utils
                     rowStart = 0;
                 }
             }
-            var calculation = new SimulatorCalculation
-            {
-                Model = new SimulatorModel
-                {
-                    Name = modelState.ModelName,
-                    Simulator = configObj.Simulator
-                },
-                Name = configObj.CalculationName,
-                Type = configObj.CalculationType,
-                UserDefinedType = configObj.CalcTypeUserDefined
-            };
-
+            
             // Update the local state with the sequence ID and the last row number
             configState.RunDataSequence = sequenceId;
             configState.RunSequenceLastRow = runDetails.Count + rowStart - 1;
@@ -410,7 +399,7 @@ namespace Cognite.Simulator.Utils
                     sequenceId,
                     rowStart,
                     runEvent.DataSetId,
-                    calculation,
+                    configObj.Calculation,
                     runDetails,
                     token).ConfigureAwait(false);
 


### PR DESCRIPTION
This runner can be configured to fetch simulation events from CDF with a given frequency, validade the events, find the sampling range for simulation inputs, call an abstract method to run the simulation (implementation should be specific to simulators) and save the run configuration as a sequence in CDF.