### PR TITLE
Allow custom rows in the integration sequence

### DIFF
--- a/Cognite.Simulator.Extensions/DataModel.cs
+++ b/Cognite.Simulator.Extensions/DataModel.cs
@@ -335,6 +335,12 @@ namespace Cognite.Simulator.Extensions
         /// Connector version key. Version of the connector associated with this simulator integration
         /// </summary>
         public const string ConnectorVersion = "connectorVersion";
+
+        /// <summary>
+        /// Simulator version key. Installed version of the simulator
+        /// </summary>
+        public const string SimulatorVersion = "simulatorVersion";
+
     }
 
     /// <summary>

--- a/Cognite.Simulator.Tests/ExtensionsTests/SequencesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/SequencesTest.cs
@@ -129,7 +129,12 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                 await sequences.UpdateSimulatorIntegrationsHeartbeat(
                     true,
                     "1.0.0",
-                    integrationsMap,
+                    externalIdToDelete,
+                    dataSetId,
+                    new Dictionary<string, string>
+                    {
+                        { "simulatorVersion", "1.2.3" }
+                    },
                     CancellationToken.None).ConfigureAwait(false);
 
                 // Verify that the sequence was updated correctly
@@ -147,7 +152,8 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                     bool isHeartbeat = values[0] == SimulatorIntegrationSequenceRows.Heartbeat;
                     bool isDataSetId = values[0] == SimulatorIntegrationSequenceRows.DataSetId;
                     bool isConnectorVersion = values[0] == SimulatorIntegrationSequenceRows.ConnectorVersion;
-                    Assert.True(isHeartbeat || isDataSetId || isConnectorVersion);
+                    bool isSimulatorVersion = values[0] == "simulatorVersion";
+                    Assert.True(isHeartbeat || isDataSetId || isConnectorVersion || isSimulatorVersion);
                     if (isHeartbeat)
                     {
                         Assert.True(long.TryParse(values[1], out long heartbeat) && heartbeat >= now);
@@ -159,6 +165,10 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                     if (isDataSetId)
                     {
                         Assert.Equal(dataSetId.ToString(), values[1]);
+                    }
+                    if (isSimulatorVersion)
+                    {
+                        Assert.Equal("1.2.3", values[1]);
                     }
                 }
             }

--- a/Cognite.Simulator.Tests/ExtensionsTests/SequencesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/SequencesTest.cs
@@ -133,7 +133,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                     dataSetId,
                     new Dictionary<string, string>
                     {
-                        { "simulatorVersion", "1.2.3" }
+                        { SimulatorIntegrationSequenceRows.SimulatorVersion, "1.2.3" }
                     },
                     CancellationToken.None).ConfigureAwait(false);
 
@@ -152,7 +152,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                     bool isHeartbeat = values[0] == SimulatorIntegrationSequenceRows.Heartbeat;
                     bool isDataSetId = values[0] == SimulatorIntegrationSequenceRows.DataSetId;
                     bool isConnectorVersion = values[0] == SimulatorIntegrationSequenceRows.ConnectorVersion;
-                    bool isSimulatorVersion = values[0] == "simulatorVersion";
+                    bool isSimulatorVersion = values[0] == SimulatorIntegrationSequenceRows.SimulatorVersion;
                     Assert.True(isHeartbeat || isDataSetId || isConnectorVersion || isSimulatorVersion);
                     if (isHeartbeat)
                     {

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
@@ -57,7 +57,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 var heartbeat = Assert.Contains(SimulatorIntegrationSequenceRows.Heartbeat, resultDict);
                 var connVersion = Assert.Contains(SimulatorIntegrationSequenceRows.ConnectorVersion, resultDict);
                 var simDataset = Assert.Contains(SimulatorIntegrationSequenceRows.DataSetId, resultDict);
-                var simVersion = Assert.Contains("simulatorVersion", resultDict);
+                var simVersion = Assert.Contains(SimulatorIntegrationSequenceRows.SimulatorVersion, resultDict);
                 Assert.True(long.Parse(heartbeat) > timestamp);
                 Assert.Equal(connector.GetConnectorVersion(), connVersion);
                 Assert.Equal(CdfTestClient.TestDataset, long.Parse(simDataset));
@@ -136,7 +136,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 true,
                 new Dictionary<string, string>
                 {
-                    { "simulatorVersion", "1.2.3" }
+                    { SimulatorIntegrationSequenceRows.SimulatorVersion, "1.2.3" }
                 },
                 token).ConfigureAwait(false);
         }

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
@@ -57,9 +57,11 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 var heartbeat = Assert.Contains(SimulatorIntegrationSequenceRows.Heartbeat, resultDict);
                 var connVersion = Assert.Contains(SimulatorIntegrationSequenceRows.ConnectorVersion, resultDict);
                 var simDataset = Assert.Contains(SimulatorIntegrationSequenceRows.DataSetId, resultDict);
+                var simVersion = Assert.Contains("simulatorVersion", resultDict);
                 Assert.True(long.Parse(heartbeat) > timestamp);
                 Assert.Equal(connector.GetConnectorVersion(), connVersion);
                 Assert.Equal(CdfTestClient.TestDataset, long.Parse(simDataset));
+                Assert.Equal("1.2.3", simVersion);
 
                 // Start the connector loop and cancel it after 5 seconds. Should be enough time
                 // to report a heartbeat back to CDF at least once.
@@ -130,7 +132,13 @@ namespace Cognite.Simulator.Tests.UtilsTests
         public override async Task Init(CancellationToken token)
         {
             await EnsureSimulatorIntegrationsSequencesExists(token).ConfigureAwait(false);
-            await UpdateIntegrationRows(true, token).ConfigureAwait(false);
+            await UpdateIntegrationRows(
+                true,
+                new Dictionary<string, string>
+                {
+                    { "simulatorVersion", "1.2.3" }
+                },
+                token).ConfigureAwait(false);
         }
 
         public override async Task Run(CancellationToken token)


### PR DESCRIPTION
This can be used, for instance, to add a row with the simulator version running on the host machine