### PR TITLE
Connector can register multiple simulators with CDF

### DIFF
--- a/Cognite.Simulator.Extensions/DataModel.cs
+++ b/Cognite.Simulator.Extensions/DataModel.cs
@@ -341,6 +341,11 @@ namespace Cognite.Simulator.Extensions
         /// </summary>
         public const string SimulatorVersion = "simulatorVersion";
 
+        /// <summary>
+        /// Api enabled key. Indicates if the simulator api is enabled for simulation runs or if it's using CDF Events
+        /// </summary>
+        public const string SimulatorsApiEnabled = "apiEnabled";
+
     }
 
     /// <summary>

--- a/Cognite.Simulator.Extensions/SequencesExtensions.cs
+++ b/Cognite.Simulator.Extensions/SequencesExtensions.cs
@@ -64,7 +64,7 @@ namespace Cognite.Simulator.Extensions
         }
 
         /// <summary>
-        /// For each simulator in <paramref name="simulators"/>, retrieve or create 
+        /// For each simulator in <paramref name="integrations"/>, retrieve or create 
         /// a simulator integration sequence in CDF
         /// </summary>
         /// <param name="sequences">CDF sequences resource</param>
@@ -156,7 +156,6 @@ namespace Cognite.Simulator.Extensions
         /// updated. Else, only the heartbeat row is updated</param>
         /// <param name="sequenceExternalId">Simulator integration sequence external id</param>
         /// <param name="update">Data to be updated, if init is set to true</param>
-        /// sequence during initialization</param>
         /// <param name="token">Cancellation token</param>
         /// <exception cref="SimulatorIntegrationSequenceException">Thrown when one or more sequences
         /// rows could not be updated. The exception contains the list of errors</exception>

--- a/Cognite.Simulator.Extensions/Types.cs
+++ b/Cognite.Simulator.Extensions/Types.cs
@@ -375,18 +375,52 @@ namespace Cognite.Simulator.Extensions
         }
     }
 
+    /// <summary>
+    /// Represents simulator integration information in CDF. Each connector can register one or more
+    /// simulator integration record with CDF
+    /// </summary>
     public class SimulatorIntegration
     {
+        /// <summary>
+        /// Name of the simulator
+        /// </summary>
         public string Simulator { get; set; }
+        
+        /// <summary>
+        /// Name of the connector
+        /// </summary>
         public string ConnectorName { get; set; }
+        
+        /// <summary>
+        /// ID of the data set that holds simulator data in CDF
+        /// </summary>
         public long? DataSetId { get; set; }
     }
 
+    /// <summary>
+    /// Represents data used to update the simulator integration information in CDF
+    /// </summary>
     public class SimulatorIntegrationUpdate : SimulatorIntegration
     {
+        /// <summary>
+        /// Version of the connector
+        /// </summary>
         public string ConnectorVersion { get; set; }
+        
+        /// <summary>
+        /// Version of the simulator
+        /// </summary>
         public string SimulatorVersion { get; set; }
+        
+        /// <summary>
+        /// Flag indicating if the connector is using Cognite's Simulator Integration API
+        /// or just core CDF resources.
+        /// </summary>
         public bool SimulatorApiEnabled { get; set; }
+        
+        /// <summary>
+        /// Any extra information that can be registered by the connector
+        /// </summary>
         public Dictionary<string, string> ExtraInformation { get; set; } = new Dictionary<string, string>();
     }
 }

--- a/Cognite.Simulator.Extensions/Types.cs
+++ b/Cognite.Simulator.Extensions/Types.cs
@@ -374,4 +374,19 @@ namespace Cognite.Simulator.Extensions
             ExternalIdOverwrite = externalId;
         }
     }
+
+    public class SimulatorIntegration
+    {
+        public string Simulator { get; set; }
+        public string ConnectorName { get; set; }
+        public long? DataSetId { get; set; }
+    }
+
+    public class SimulatorIntegrationUpdate : SimulatorIntegration
+    {
+        public string ConnectorVersion { get; set; }
+        public string SimulatorVersion { get; set; }
+        public bool SimulatorApiEnabled { get; set; }
+        public Dictionary<string, string> ExtraInformation { get; set; } = new Dictionary<string, string>();
+    }
 }

--- a/Cognite.Simulator.Tests/ExtensionsTests/SequencesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/SequencesTest.cs
@@ -52,17 +52,26 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             using var provider = services.BuildServiceProvider();
             var cdf = provider.GetRequiredService<Client>();
             var sequences = cdf.Sequences;
-            var simulators = new Dictionary<string, long>
+            var simulators = new List<SimulatorIntegration>
                 {
-                    { "PROSPER", dataSetId }, // Assumes this one exists in CDF
-                    { "SomeSimulator", dataSetId } // This one should be created
+                    new SimulatorIntegration
+                    {
+                        Simulator = "PROSPER", // Assumes this one exists in CDF
+                        DataSetId = dataSetId,
+                        ConnectorName = connectorName,
+                    },
+                    new SimulatorIntegration
+                    {
+                        Simulator = "SomeSimulator", // This one should be created
+                        DataSetId = dataSetId,
+                        ConnectorName = connectorName,
+                    }
                 };
 
             string? externalIdToDelete = null;
             try
             {
                 var integrations = await sequences.GetOrCreateSimulatorIntegrations(
-                    connectorName,
                     simulators,
                     CancellationToken.None).ConfigureAwait(false);
 
@@ -70,13 +79,13 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                 foreach (var sim in simulators)
                 {
                     var seq = Assert.Single(integrations, i =>
-                        i.DataSetId == sim.Value &&
+                        i.DataSetId == sim.DataSetId &&
                         i.Metadata[BaseMetadata.DataTypeKey] == SimulatorIntegrationMetadata.DataType.MetadataValue() &&
-                        i.Metadata[BaseMetadata.SimulatorKey] == sim.Key &&
-                        i.Metadata[SimulatorIntegrationMetadata.ConnectorNameKey] == connectorName);
+                        i.Metadata[BaseMetadata.SimulatorKey] == sim.Simulator &&
+                        i.Metadata[SimulatorIntegrationMetadata.ConnectorNameKey] == sim.ConnectorName);
 
                     Assert.Equal(2, seq.Columns.Count());
-                    if (sim.Key == "SomeSimulator")
+                    if (sim.Simulator == "SomeSimulator")
                     {
                         externalIdToDelete = seq.ExternalId;
                     }
@@ -103,9 +112,14 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             using var provider = services.BuildServiceProvider();
             var cdf = provider.GetRequiredService<Client>();
             var sequences = cdf.Sequences;
-            var simulators = new Dictionary<string, long>
+            var simulators = new List<SimulatorIntegration>
                 {
-                    { "TestHeartbeatSimulator", dataSetId },
+                    new SimulatorIntegration
+                    {
+                        Simulator = "TestHeartbeatSimulator",
+                        DataSetId = dataSetId,
+                        ConnectorName = connectorName,
+                    }
                 };
 
             string? externalIdToDelete = null;
@@ -113,27 +127,25 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             {
                 // Create a test simulator integration sequence
                 var integrations = await sequences.GetOrCreateSimulatorIntegrations(
-                    connectorName,
                     simulators,
                     CancellationToken.None).ConfigureAwait(false);
 
                 Assert.NotEmpty(integrations);
                 externalIdToDelete = integrations.First().ExternalId;
-                var integrationsMap = integrations.ToDictionary(
-                    i =>  i.ExternalId,
-                    i => dataSetId);
                 
                 var now = DateTime.UtcNow.ToUnixTimeMilliseconds();
                 
                 // Update the sequence with connector heartbeat
                 await sequences.UpdateSimulatorIntegrationsHeartbeat(
-                    true,
-                    "1.0.0",
                     externalIdToDelete,
-                    dataSetId,
-                    new Dictionary<string, string>
+                    true,
+                    new SimulatorIntegrationUpdate
                     {
-                        { SimulatorIntegrationSequenceRows.SimulatorVersion, "1.2.3" }
+                        Simulator = "TestHeartbeatSimulator",
+                        DataSetId = dataSetId,
+                        ConnectorName = connectorName,
+                        ConnectorVersion = "1.0.0",
+                        SimulatorVersion = "1.2.3",
                     },
                     CancellationToken.None).ConfigureAwait(false);
 
@@ -153,7 +165,8 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                     bool isDataSetId = values[0] == SimulatorIntegrationSequenceRows.DataSetId;
                     bool isConnectorVersion = values[0] == SimulatorIntegrationSequenceRows.ConnectorVersion;
                     bool isSimulatorVersion = values[0] == SimulatorIntegrationSequenceRows.SimulatorVersion;
-                    Assert.True(isHeartbeat || isDataSetId || isConnectorVersion || isSimulatorVersion);
+                    bool isApiEnabled = values[0] == SimulatorIntegrationSequenceRows.SimulatorsApiEnabled;
+                    Assert.True(isHeartbeat || isDataSetId || isConnectorVersion || isSimulatorVersion || isApiEnabled);
                     if (isHeartbeat)
                     {
                         Assert.True(long.TryParse(values[1], out long heartbeat) && heartbeat >= now);
@@ -169,6 +182,10 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                     if (isSimulatorVersion)
                     {
                         Assert.Equal("1.2.3", values[1]);
+                    }
+                    if (isApiEnabled)
+                    {
+                        Assert.Equal("False", values[1]);
                     }
                 }
             }

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
@@ -126,6 +126,11 @@ namespace Cognite.Simulator.Tests.UtilsTests
             ILogger<ConnectorBase> logger) : 
             base(
                 cdf,
+                new ConnectorConfig
+                {
+                    NamePrefix = "Test Connector",
+                    AddMachineNameSuffix = false
+                },
                 new List<SimulatorConfig>
                 {
                     config
@@ -134,11 +139,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
         {
             _pipeline = pipeline;
             _config = config;
-        }
-
-        public override string GetConnectorName()
-        {
-            return "Test Connector";
         }
 
         public override string GetConnectorVersion()
@@ -151,15 +151,16 @@ namespace Cognite.Simulator.Tests.UtilsTests
             return TimeSpan.FromSeconds(2);
         }
 
+        public override string GetSimulatorVersion(string simulator)
+        {
+            return "1.2.3";
+        }
+
         public override async Task Init(CancellationToken token)
         {
             await EnsureSimulatorIntegrationsSequencesExists(token).ConfigureAwait(false);
             await UpdateIntegrationRows(
                 true,
-                new Dictionary<string, string>
-                {
-                    { SimulatorIntegrationSequenceRows.SimulatorVersion, "1.2.3" }
-                },
                 token).ConfigureAwait(false);
             await _pipeline.Init(_config, token).ConfigureAwait(false);
         }

--- a/Cognite.Simulator.Utils/Configuration.cs
+++ b/Cognite.Simulator.Utils/Configuration.cs
@@ -118,6 +118,8 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         public PipelineNotificationConfig PipelineNotification { get; set; }
 
+        public bool UseSimulatorsApi { get; set; }
+
         /// <summary>
         /// Returns the connector name, composed of the configured prefix and suffix
         /// </summary>

--- a/Cognite.Simulator.Utils/Configuration.cs
+++ b/Cognite.Simulator.Utils/Configuration.cs
@@ -118,6 +118,10 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         public PipelineNotificationConfig PipelineNotification { get; set; }
 
+        /// <summary>
+        /// If <c>true</c>, the connector will use Cognite's Simulator Integration API (requires enabling
+        /// capabilities in CDF). Else, the connector will use only core CDF resources
+        /// </summary>
         public bool UseSimulatorsApi { get; set; }
 
         /// <summary>

--- a/Cognite.Simulator.Utils/ConnectorBase.cs
+++ b/Cognite.Simulator.Utils/ConnectorBase.cs
@@ -35,6 +35,7 @@ namespace Cognite.Simulator.Utils
         /// Initialize the connector with the given parameters
         /// </summary>
         /// <param name="cdf">CDF client wrapper</param>
+        /// <param name="config">Connector configuration</param>
         /// <param name="simulators">List of simulator configurations</param>
         /// <param name="logger">Logger</param>
         public ConnectorBase(
@@ -86,8 +87,20 @@ namespace Cognite.Simulator.Utils
         /// <returns>Connector version</returns>
         public abstract string GetConnectorVersion();
 
+        /// <summary>
+        /// Returns the version of the given simulator. The connector reads the version and
+        /// report it back to CDF
+        /// </summary>
+        /// <param name="simulator">Name of the simulator</param>
+        /// <returns>Version</returns>
         public abstract string GetSimulatorVersion(string simulator);
 
+        /// <summary>
+        /// Returns any extra information about the simulator integration. This information
+        /// is reported back to CDF
+        /// </summary>
+        /// <param name="simulator"></param>
+        /// <returns></returns>
         public virtual Dictionary<string, string> GetExtraInformation(string simulator)
         {
             return new Dictionary<string, string>();
@@ -111,6 +124,10 @@ namespace Cognite.Simulator.Utils
             return TimeSpan.FromSeconds(_config.StatusInterval);
         }
 
+        /// <summary>
+        /// Indicates if this connectors should use Cognite's Simulator Integration API
+        /// </summary>
+        /// <returns></returns>
         public virtual bool ApiEnabled()
         {
             return _config.UseSimulatorsApi;


### PR DESCRIPTION
Previously, the connector could register multiple simulators, but it was not able to update the information individually. That is, all simulators would have the same 'simulator version'.
Also, a new field was added to indicate if the connector supports the SimInt API. This is disabled by default.