### PR TITLE
[DEGR-2510] Allow commands without type

### DIFF
--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -263,6 +263,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
         public override void RunCommand(string command, Dictionary<string, string> arguments)
         {
+            if (command == null)
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
             if (command == "Simulate")
             {
                 _output = _inputs.Sum();

--- a/Cognite.Simulator.Utils/RoutineImplementationBase.cs
+++ b/Cognite.Simulator.Utils/RoutineImplementationBase.cs
@@ -72,9 +72,11 @@ namespace Cognite.Simulator.Utils
             Dictionary<string, string> arguments);
 
         /// <summary>
-        /// Invoke the given command on the simulator using the provided arguments
+        /// Invoke the given command on the simulator using the provided arguments.
+        /// The <paramref name="command"/> parameter can be <c>null</c> in case 
+        /// the provided arguments are sufficient to run the command
         /// </summary>
-        /// <param name="command">Command to invoke</param>
+        /// <param name="command">Command to invoke, or <c>null</c></param>
         /// <param name="arguments">Extra arguments</param>
         public abstract void RunCommand(
             string command, 
@@ -153,7 +155,7 @@ namespace Cognite.Simulator.Utils
         {
             if (!arguments.TryGetValue("type", out string argType))
             {
-                throw new SimulationException($"Command error: Assignment type not defined");
+                argType = null;
             }
             var extraArgs = arguments.Where(s => s.Key != "type")
                 .ToDictionary(dict => dict.Key, dict => dict.Value);


### PR DESCRIPTION
OpenServer commands, for instance, do not need a type. They are executed with an 'address' as argument