### PR TITLE
[DEGR-2598] Manual inputs outside of the routine + persisted

### DIFF
--- a/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
@@ -230,13 +230,13 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     Assert.Equal("SimConnect-IntegrationTests-IT1-SampledSsd", input.SampleExternalId);
                 }
 
-                Assert.NotEmpty(simConf.InputManualValues);
-                foreach (var input in simConf.InputManualValues)
+                Assert.NotEmpty(simConf.InputConstants);
+                foreach (var input in simConf.InputConstants)
                 {
                     Assert.NotNull(input.Value);
                     Assert.NotNull(input.Type);
                     Assert.NotNull(input.Name);
-                    Assert.Equal("SimConnect-IntegrationTests-IM1-SampledSsd", input.SampleExternalId);
+                    Assert.Equal("SimConnect-IntegrationTests-IC1-SampledSsd", input.SaveTimeseriesExternalId);
                 }
 
                 var simConfState = lib.GetSimulationConfigurationState(

--- a/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
@@ -233,7 +233,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 Assert.NotEmpty(simConf.InputConstants);
                 foreach (var input in simConf.InputConstants)
                 {
-                    Assert.NotNull(input.Value);
+                    Assert.Equal(input.Value, "42");
                     Assert.NotNull(input.Type);
                     Assert.NotNull(input.Name);
                     Assert.Equal("SimConnect-IntegrationTests-IC1-SampledSsd", input.SaveTimeseriesExternalId);

--- a/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
@@ -197,7 +197,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
                 Assert.NotEmpty(lib.State);
                 var state = Assert.Contains(
-                    "PROSPER-SC-UserDefined-SRT-Connector_Test_Model", // This simulator configuration should exist in CDF
+                    "PROSPER-SC-UserDefined-SRTWCI-Connector_Test_Model", // This simulator configuration should exist in CDF
                     (IReadOnlyDictionary<string, TestConfigurationState>)lib.State);
                 Assert.Equal("PROSPER", state.Source);
                 Assert.Equal("Connector Test Model", state.ModelName);
@@ -217,29 +217,24 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 Assert.True(File.Exists(state.FilePath));
 
                 var simConf = lib.GetSimulationConfiguration(
-                    "PROSPER", "Connector Test Model", "Simulation Runner Test");
+                    "PROSPER", "Connector Test Model", "Simulation Runner Test With Constant Inputs");
                 Assert.NotNull(simConf);
                 Assert.Equal("UserDefined", simConf.CalculationType);
-                Assert.Equal("Simulation Runner Test", simConf.CalculationName);
-                Assert.Equal("SRT", simConf.CalcTypeUserDefined);
-                foreach (var input in simConf.InputTimeSeries)
-                {
-                    Assert.NotNull(input.Name);
-                    Assert.NotNull(input.SensorExternalId);
-                    Assert.Equal("SimConnect-IntegrationTests-IT1-SampledSsd", input.SampleExternalId);
-                }
-
+                Assert.Equal("Simulation Runner Test With Constant Inputs", simConf.CalculationName);
+                Assert.Equal("SRTWCI", simConf.CalcTypeUserDefined);
+                
+                Assert.Empty(simConf.InputTimeSeries);
                 Assert.NotEmpty(simConf.InputConstants);
                 foreach (var input in simConf.InputConstants)
                 {
-                    Assert.Equal(input.Value, "42");
+                    Assert.NotNull(input.Value);
                     Assert.NotNull(input.Type);
                     Assert.NotNull(input.Name);
-                    Assert.Equal("SimConnect-IntegrationTests-IC1-SampledSsd", input.SaveTimeseriesExternalId);
+                    Assert.StartsWith("SimConnect-IntegrationTests-IC", input.SaveTimeseriesExternalId);
                 }
 
                 var simConfState = lib.GetSimulationConfigurationState(
-                    "PROSPER", "Connector Test Model", "Simulation Runner Test");
+                    "PROSPER", "Connector Test Model", "Simulation Runner Test With Constant Inputs");
                 Assert.NotNull(simConfState);
                 Assert.Equivalent(state, simConfState, true);
             }

--- a/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
@@ -174,8 +174,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
         }
 
         [Fact]
-        [Trait("Category", "FileLibraryIntegrationTest")]
-        public async Task TestConfigurationLibraryWithManualInputs()
+        public async Task TestConfigurationLibraryWithConstInputs()
         {
             var services = new ServiceCollection();
             services.AddCogniteTestClient();

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -35,9 +35,9 @@ namespace Cognite.Simulator.Tests.UtilsTests
         private const long validationEndOverwrite = 1631304000000L;
 
         [Theory]
-        [InlineData("Simulation Runner Test")]
-        [InlineData("Simulation Runner Test With Constant Inputs")]
-        public async Task TestSimulationRunnerBase(String simulationConfigurationName)
+        [InlineData("Simulation Runner Test", false)]
+        [InlineData("Simulation Runner Test With Constant Inputs", true)]
+        public async Task TestSimulationRunnerBase(String simulationConfigurationName, bool useConstInputs)
         {
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
@@ -96,7 +96,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 var inTsIds = configObj.InputTimeSeries.Select(o => o.SampleExternalId).ToList();
                 tsToDelete.AddRange(inTsIds);
 
-                if (configObj.InputConstants != null) {
+                if (useConstInputs) {
                     var inConstIds = configObj.InputConstants.Select(o => o.SaveTimeseriesExternalId).ToList();
                     tsToDelete.AddRange(inConstIds);
                 }

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -34,8 +34,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
     {
         private const long validationEndOverwrite = 1631304000000L;
 
-        [Fact]
-        public async Task TestSimulationRunnerBase()
+        [Theory]
+        [InlineData("Simulation Runner Test")]
+        [InlineData("Simulation Runner Test With Constant Inputs")]
+        public async Task TestSimulationRunnerBase(String simulationConfigurationName)
         {
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
@@ -93,6 +95,11 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 tsToDelete.AddRange(outTsIds);
                 var inTsIds = configObj.InputTimeSeries.Select(o => o.SampleExternalId).ToList();
                 tsToDelete.AddRange(inTsIds);
+
+                if (configObj.InputConstants != null) {
+                    var inConstIds = configObj.InputConstants.Select(o => o.SaveTimeseriesExternalId).ToList();
+                    tsToDelete.AddRange(inConstIds);
+                }
 
                 // Create a simulation event ready to run for the test configuration
                 var events = await cdf.Events.CreateSimulationEventReadyToRun(

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -88,7 +88,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     "PROSPER-SC-UserDefined-SRT-Connector_Test_Model", // This simulator configuration should exist in CDF
                     (IReadOnlyDictionary<string, TestConfigurationState>)configLib.State);
                 var configObj = configLib.GetSimulationConfiguration(
-                    "PROSPER", "Connector Test Model", "UserDefined", "SRT");
+                    "PROSPER", "Connector Test Model", simulationConfigurationName);
                 Assert.NotNull(configObj);
 
                 var outTsIds = configObj.OutputTimeSeries.Select(o => o.ExternalId).ToList();

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -35,9 +35,9 @@ namespace Cognite.Simulator.Tests.UtilsTests
         private const long validationEndOverwrite = 1631304000000L;
 
         [Theory]
-        [InlineData("Simulation Runner Test", false)]
-        [InlineData("Simulation Runner Test With Constant Inputs", true)]
-        public async Task TestSimulationRunnerBase(String simulationConfigurationName, bool useConstInputs)
+        [InlineData("Simulation Runner Test", "SRT", false)]
+        [InlineData("Simulation Runner Test With Constant Inputs", "SRTWCI", true)]
+        public async Task TestSimulationRunnerBase(String calculationName, String calcType, bool useConstInputs)
         {
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
@@ -85,10 +85,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
                 Assert.NotEmpty(configLib.State);
                 var configState = Assert.Contains(
-                    "PROSPER-SC-UserDefined-SRT-Connector_Test_Model", // This simulator configuration should exist in CDF
+                    $"PROSPER-SC-UserDefined-{calcType}-Connector_Test_Model", // This simulator configuration should exist in CDF
                     (IReadOnlyDictionary<string, TestConfigurationState>)configLib.State);
                 var configObj = configLib.GetSimulationConfiguration(
-                    "PROSPER", "Connector Test Model", simulationConfigurationName);
+                    "PROSPER", "Connector Test Model", calculationName);
                 Assert.NotNull(configObj);
 
                 var outTsIds = configObj.OutputTimeSeries.Select(o => o.ExternalId).ToList();
@@ -97,8 +97,9 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 tsToDelete.AddRange(inTsIds);
 
                 if (useConstInputs) {
-                    var inConstIds = configObj.InputConstants.Select(o => o.SaveTimeseriesExternalId).ToList();
-                    tsToDelete.AddRange(inConstIds);
+                    var inConstTsIds = configObj.InputConstants.Select(o => o.SaveTimeseriesExternalId).ToList();
+                    tsToDelete.AddRange(inConstTsIds);
+                    inTsIds.AddRange(inConstTsIds);
                 }
 
                 // Create a simulation event ready to run for the test configuration

--- a/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
@@ -590,7 +590,7 @@ namespace Cognite.Simulator.Utils
         /// <summary>
         /// The value of the manual input
         /// </summary>
-        public double Value { get; set; }
+        public string Value { get; set; }
 
         /// <summary>
         /// External ID to use when saving the input sample in CDF

--- a/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
@@ -324,9 +324,9 @@ namespace Cognite.Simulator.Utils
     public class SimulationConfigurationWithRoutine : SimulationConfigurationWithDataSampling
     {
         /// <summary>
-        /// Simulation manual inputs configuration
+        /// Simulation manual value inputs configuration
         /// </summary>
-        public IEnumerable<InputManualValueConfiguration> InputManualValues { get; set; }
+        public IEnumerable<InputConstantConfiguration> InputConstants { get; set; }
         
         /// <summary>
         /// Times series that will hold simulation output data points
@@ -563,9 +563,9 @@ namespace Cognite.Simulator.Utils
     }
 
     /// <summary>
-    /// Input time series configuration
+    /// Manually input the value into routine
     /// </summary>
-    public class InputManualValueConfiguration
+    public class InputConstantConfiguration
     {       
         /// <summary>
         /// Input name
@@ -595,7 +595,7 @@ namespace Cognite.Simulator.Utils
         /// <summary>
         /// External ID to use when saving the input sample in CDF
         /// </summary>
-        public string SampleExternalId { get; set; }
+        public string SaveTimeseriesExternalId { get; set; }
     }
     
     /// <summary>

--- a/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
@@ -324,6 +324,11 @@ namespace Cognite.Simulator.Utils
     public class SimulationConfigurationWithRoutine : SimulationConfigurationWithDataSampling
     {
         /// <summary>
+        /// Simulation manual inputs configuration
+        /// </summary>
+        public IEnumerable<InputManualValueConfiguration> InputManualValues { get; set; }
+        
+        /// <summary>
         /// Times series that will hold simulation output data points
         /// </summary>
         public IEnumerable<OutputTimeSeriesConfiguration> OutputTimeSeries { get; set; }
@@ -550,6 +555,42 @@ namespace Cognite.Simulator.Utils
         /// <c>sum</c>, <c>interpolation</c>, <c>stepInterpolation</c>, <c>totalVariation</c>, <c>continuousVariance</c>, <c>discreteVariance</c>
         /// </summary>
         public string AggregateType { get; set; }
+
+        /// <summary>
+        /// External ID to use when saving the input sample in CDF
+        /// </summary>
+        public string SampleExternalId { get; set; }
+    }
+
+    /// <summary>
+    /// Input time series configuration
+    /// </summary>
+    public class InputManualValueConfiguration
+    {       
+        /// <summary>
+        /// Input name
+        /// </summary>
+        public string Name { get; set; }
+        
+        /// <summary>
+        /// Input type
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Input unit (e.g. degC, BARg)
+        /// </summary>
+        public string Unit { get; set; }
+        
+        /// <summary>
+        /// Input unit type (e.g. Temperature, Pressure)
+        /// </summary>
+        public string UnitType { get; set; }
+
+        /// <summary>
+        /// The value of the manual input
+        /// </summary>
+        public double Value { get; set; }
 
         /// <summary>
         /// External ID to use when saving the input sample in CDF

--- a/Cognite.Simulator.Utils/RoutineImplementationBase.cs
+++ b/Cognite.Simulator.Utils/RoutineImplementationBase.cs
@@ -222,6 +222,9 @@ namespace Cognite.Simulator.Utils
                     var matchingInputManualValues = _config.InputConstants.Where(i => i.Type == argValue).ToList();
                     if (matchingInputManualValues.Any() && _inputData.ContainsKey(argValue))
                     {
+                        var inputManualValue = matchingInputManualValues.First();
+                        extraArgs.Add("unit", inputManualValue.Unit);
+                        extraArgs.Add("unitType", inputManualValue.UnitType);
                         // Set manual input
                         SetManualInput(_inputData[argValue].ToString(), extraArgs);
                     }

--- a/Cognite.Simulator.Utils/RoutineImplementationBase.cs
+++ b/Cognite.Simulator.Utils/RoutineImplementationBase.cs
@@ -205,27 +205,37 @@ namespace Cognite.Simulator.Utils
             var extraArgs = arguments.Where(s => s.Key != "type" && s.Key != "value")
                 .ToDictionary(dict => dict.Key, dict => dict.Value);
 
-            if (argType == "inputTimeSeries")
-            {
-                var matchingInputs = _config.InputTimeSeries.Where(i => i.Type == argValue).ToList();
-                if (matchingInputs.Any() && _inputData.ContainsKey(argValue))
-                {
-                    // Set input time series
-                    SetTimeSeriesInput(matchingInputs.First(), _inputData[argValue], extraArgs);
-                }
-                else
-                {
-                    throw new SimulationException($"Set error: Input time series with key {argValue} not found");
-                }
-            }
-            else if (argType == "manual")
-            {
-                // Set manual input
-                SetManualInput(argValue, extraArgs);
-            }
-            else
-            {
-                throw new SimulationException($"Set error: Invalid argument type {argType}");
+            switch(argType) {
+                case "inputTimeSeries":
+                    var matchingInputs = _config.InputTimeSeries.Where(i => i.Type == argValue).ToList();
+                    if (matchingInputs.Any() && _inputData.ContainsKey(argValue))
+                    {
+                        // Set input time series
+                        SetTimeSeriesInput(matchingInputs.First(), _inputData[argValue], extraArgs);
+                    }
+                    else
+                    {
+                        throw new SimulationException($"Set error: Input time series with key {argValue} not found");
+                    }
+                    break;
+                case "inputManualValues":
+                    var matchingInputManualValues = _config.InputManualValues.Where(i => i.Type == argValue).ToList();
+                    if (matchingInputManualValues.Any() && _inputData.ContainsKey(argValue))
+                    {
+                        // Set manual input
+                        SetManualInput(_inputData[argValue].ToString(), extraArgs);
+                    }
+                    else
+                    {
+                        throw new SimulationException($"Set error: Manual value input with key {argValue} not found");
+                    }
+                    break;
+                case "manual":
+                    // Set manual input (from inside the routine, legacy)
+                    SetManualInput(argValue, extraArgs);
+                    break;
+                default:
+                    throw new SimulationException($"Set error: Invalid argument type {argType}");
             }
         }    
     }

--- a/Cognite.Simulator.Utils/RoutineImplementationBase.cs
+++ b/Cognite.Simulator.Utils/RoutineImplementationBase.cs
@@ -218,8 +218,8 @@ namespace Cognite.Simulator.Utils
                         throw new SimulationException($"Set error: Input time series with key {argValue} not found");
                     }
                     break;
-                case "inputManualValues":
-                    var matchingInputManualValues = _config.InputManualValues.Where(i => i.Type == argValue).ToList();
+                case "inputConstant":
+                    var matchingInputManualValues = _config.InputConstants.Where(i => i.Type == argValue).ToList();
                     if (matchingInputManualValues.Any() && _inputData.ContainsKey(argValue))
                     {
                         // Set manual input

--- a/Cognite.Simulator.Utils/RoutineImplementationBase.cs
+++ b/Cognite.Simulator.Utils/RoutineImplementationBase.cs
@@ -224,7 +224,9 @@ namespace Cognite.Simulator.Utils
                     {
                         var inputManualValue = matchingInputManualValues.First();
                         extraArgs.Add("unit", inputManualValue.Unit);
-                        extraArgs.Add("unitType", inputManualValue.UnitType);
+                        if (inputManualValue.UnitType != null) {
+                            extraArgs.Add("unitType", inputManualValue.UnitType);
+                        }
                         // Set manual input
                         SetManualInput(_inputData[argValue].ToString(), extraArgs);
                     }

--- a/Cognite.Simulator.Utils/RoutineRunnerBase.cs
+++ b/Cognite.Simulator.Utils/RoutineRunnerBase.cs
@@ -120,13 +120,19 @@ namespace Cognite.Simulator.Utils
                         simInput.OverwriteTimeSeriesId(inputValue.SaveTimeseriesExternalId);
                     }
 
-                    inputData[inputValue.Type] = inputValue.Value;
+                    
+                    if (!double.TryParse(inputValue.Value, out var inputConstValue))
+                    {
+                        throw new SimulationException($"Could not parse input constant {inputValue.Name} with value {inputValue.Value}. Only double precision values are supported.");
+                    }
+
+                    inputData[inputValue.Type] = inputConstValue;
                     inputTsToCreate.Add(simInput);
                     dpsToCreate.Add(
                         new Identity(simInput.TimeSeriesExternalId),
                         new List<Datapoint> 
                         { 
-                            new Datapoint(samplingRange.Midpoint, inputValue.Value) 
+                            new Datapoint(samplingRange.Midpoint, inputConstValue) 
                         });
                 }
             }

--- a/Cognite.Simulator.Utils/RoutineRunnerBase.cs
+++ b/Cognite.Simulator.Utils/RoutineRunnerBase.cs
@@ -101,6 +101,36 @@ namespace Cognite.Simulator.Utils
             var inputTsToCreate = new List<SimulationInput>();
             IDictionary<Identity, IEnumerable<Datapoint>> dpsToCreate = new Dictionary<Identity, IEnumerable<Datapoint>>();
 
+            // Collect manual inputs, to run simulations and to store as time series and data points
+            if (configObj.InputManualValues != null) {
+                foreach (var inputValue in configObj.InputManualValues)
+                {
+                    var simInput = new SimulationInput
+                    {
+                        Calculation = configObj.Calculation,
+                        Type = inputValue.Type,
+                        Name = inputValue.Name,
+                        Unit = inputValue.Unit,
+                    };
+
+                    // If the manual input is to be saved with an external ID different than the
+                    // auto-generated one
+                    if (!string.IsNullOrEmpty(inputValue.SampleExternalId))
+                    {
+                        simInput.OverwriteTimeSeriesId(inputValue.SampleExternalId);
+                    }
+
+                    inputData[inputValue.Type] = inputValue.Value;
+                    inputTsToCreate.Add(simInput);
+                    dpsToCreate.Add(
+                        new Identity(simInput.TimeSeriesExternalId),
+                        new List<Datapoint> 
+                        { 
+                            new Datapoint(samplingRange.Midpoint, inputValue.Value) 
+                        });
+                }
+            }
+
             // Collect sampled inputs, to run simulations and to store as time series and data points
             foreach (var inputTs in configObj.InputTimeSeries)
             {

--- a/Cognite.Simulator.Utils/RoutineRunnerBase.cs
+++ b/Cognite.Simulator.Utils/RoutineRunnerBase.cs
@@ -102,8 +102,8 @@ namespace Cognite.Simulator.Utils
             IDictionary<Identity, IEnumerable<Datapoint>> dpsToCreate = new Dictionary<Identity, IEnumerable<Datapoint>>();
 
             // Collect manual inputs, to run simulations and to store as time series and data points
-            if (configObj.InputManualValues != null) {
-                foreach (var inputValue in configObj.InputManualValues)
+            if (configObj.InputConstants != null) {
+                foreach (var inputValue in configObj.InputConstants)
                 {
                     var simInput = new SimulationInput
                     {
@@ -115,9 +115,9 @@ namespace Cognite.Simulator.Utils
 
                     // If the manual input is to be saved with an external ID different than the
                     // auto-generated one
-                    if (!string.IsNullOrEmpty(inputValue.SampleExternalId))
+                    if (!string.IsNullOrEmpty(inputValue.SaveTimeseriesExternalId))
                     {
-                        simInput.OverwriteTimeSeriesId(inputValue.SampleExternalId);
+                        simInput.OverwriteTimeSeriesId(inputValue.SaveTimeseriesExternalId);
                     }
 
                     inputData[inputValue.Type] = inputValue.Value;


### PR DESCRIPTION
What’s done:

- adds "constant" input value to be outside of the routine and adds a reference to it from the routine (as it’s done for time-series inputs)
- keeps the old "manual input" on the routine, we can remove this eventually
- saves all inputs to time series by default (same as input time-series)
- passes unit/unitType param
- not a breaking change

What to be done in the future:
- routine data model versioning (I strongly believe this better to delay until the time we use something else rather than CDF json-files)

piece of the routine with only manual inputs (based on shower mixer):
```
{
  ///...params skipped
  "inputConstants": [
    {
      "name": "Cold Water Temperature - Constant",
      "saveTimeseriesExternalId": "DWSIM-INPUT-constinput-CWTC-ShowerMixer",
      "value": "10",
      "unit": "C",
      "unitType": "Temperature",
      "type": "CWTC"
    },
    {
      "name": "Cold Water Pressure - Constant",
      "saveTimeseriesExternalId": "DWSIM-INPUT-constinput-CWPC-ShowerMixer",
      "value": "3.6",
      "unit": "bar",
      "unitType": "Pressure",
      "type": "CWPC"
    },
    {
      "name": "Cold Water Volumetric Flow - Constant",
      "saveTimeseriesExternalId": "DWSIM-INPUT-constinput-CWVFC-ShowerMixer",
      "value": "0.37",
      "unit": "m3/h",
      "unitType": "Volumetric Flow",
      "type": "CWVFC"
    },
    {
      "name": "Hot Water Temperature - Constant",
      "saveTimeseriesExternalId": "DWSIM-INPUT-constinput-HWTC-ShowerMixer",
      "value": "69",
      "unit": "C",
      "unitType": "Temperature",
      "type": "HWTC"
    },
    {
      "name": "Hot Water Pressure - Constant",
      "saveTimeseriesExternalId": "DWSIM-INPUT-constinput-HWPC-ShowerMixer",
      "value": "2.8",
      "unit": "bar",
      "unitType": "Pressure",
      "type": "HWPC"
    },
    {
      "name": "Hot Water Volumetric Flow - Constant",
      "saveTimeseriesExternalId": "DWSIM-INPUT-constinput-HWVFC-ShowerMixer",
      "value": "0.19",
      "unit": "m3/h",
      "unitType": "Volumetric Flow",
      "type": "HWVFC"
    }
  ],
  "inputTimeSeries": [],
  "outputTimeSeries": [.....],
  "outputSequences": [],
  "calcTypeUserDefined": "constinput",
  "routine": [
    {
      "order": 1,
      "description": "Set Inputs",
      "steps": [
        {
          "step": 1,
          "type": "Set",
          "arguments": {
            "type": "inputConstant",
            "value": "CWTC",
            "objectName": "Cold water",
            "objectProperty": "Temperature"
          }
        },
        {
          "step": 2,
          "type": "Set",
          "arguments": {
            "type": "inputConstant",
            "value": "CWPC",
            "objectName": "Cold water",
            "objectProperty": "Pressure"
          }
        },
        {
          "step": 3,
          "type": "Set",
          "arguments": {
            "type": "inputConstant",
            "value": "CWVFC",
            "objectName": "Cold water",
            "objectProperty": "Volumetric Flow"
          }
        },
        {
          "step": 4,
          "type": "Set",
          "arguments": {
            "type": "inputConstant",
            "value": "HWTC",
            "objectName": "Hot water",
            "objectProperty": "Temperature"
          }
        },
        {
          "step": 5,
          "type": "Set",
          "arguments": {
            "type": "inputConstant",
            "value": "HWPC",
            "objectName": "Hot water",
            "objectProperty": "Pressure"
          }
        },
        {
          "step": 6,
          "type": "Set",
          "arguments": {
            "type": "inputConstant",
            "value": "HWVFC",
            "objectName": "Hot water",
            "objectProperty": "Volumetric Flow"
          }
        }
      ]
    }
....
    }
  ]
}
```

example based on shower mixer with only constant inputs:
<img width="918" alt="Screenshot 2023-06-23 at 09 23 46" src="https://github.com/cognitedata/dotnet-simulator-utils/assets/10908415/a19daa73-b118-41e6-adde-e9e4f248a093">
