### PR TITLE
DataModels-based heartbeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .idea
 *.user
 .envrc
+.env

--- a/Cognite.Simulator.Extensions/DataModel.cs
+++ b/Cognite.Simulator.Extensions/DataModel.cs
@@ -348,6 +348,28 @@ namespace Cognite.Simulator.Extensions
     }
 
     /// <summary>
+    /// Constants used in the simulator integration data model
+    /// E.g. external ids of the containers and spaces
+    /// </summary>
+    public static class SimulatorIntegrationDms
+    {
+        /// <summary>
+        /// Data Models Simulators space
+        /// </summary>
+        public const string Space = "SimulatorIntegrationSpace"; // later this will be replaced with the internal CDF space
+
+        /// <summary>
+        /// Data Models Simulator Integration container external id
+        /// </summary>
+        public const string SimulatorIntegrationContainer = "SimulatorIntegration";
+
+        /// <summary>
+        /// Data Models Simulator container external id
+        /// </summary>
+        public const string SimulatorContainer = "Simulator";
+    }
+
+    /// <summary>
     /// Types of simulator resources that can be stored in CDF
     /// </summary>
     public enum SimulatorDataType

--- a/Cognite.Simulator.Extensions/DataModel.cs
+++ b/Cognite.Simulator.Extensions/DataModel.cs
@@ -367,6 +367,11 @@ namespace Cognite.Simulator.Extensions
         /// Data Models Simulator container external id
         /// </summary>
         public const string SimulatorContainer = "Simulator";
+
+        /// <summary>
+        /// Data Models Simulator Integration view version
+        /// </summary>
+        public const string ViewVersion = "1";
     }
 
     /// <summary>

--- a/Cognite.Simulator.Extensions/ModelExtensions.cs
+++ b/Cognite.Simulator.Extensions/ModelExtensions.cs
@@ -16,7 +16,7 @@ namespace Cognite.Simulator.Extensions
     {
         /// <summary>
         /// Update the simulator integration data model with the connector heartbeat (last time seen)
-        /// This requires a SimulatorIntegration datamodel in SimulatorIntegrationSpace:
+        /// This requires a SimulatorIntegration model in SimulatorIntegrationSpace:
         /// type Simulator @view(version: "1") {
         ///     name: String!
         ///     description: String

--- a/Cognite.Simulator.Extensions/ModelExtensions.cs
+++ b/Cognite.Simulator.Extensions/ModelExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Cognite.Extensions;
-using Cognite.Extractor.Common;
-using CogniteSdk;
+﻿using Cognite.Extractor.Common;
 using CogniteSdk.Beta.DataModels;
 using CogniteSdk.Resources.Beta;
 using System;
@@ -29,16 +27,13 @@ namespace Cognite.Simulator.Extensions
             SimulatorIntegrationUpdate update,
             CancellationToken token)
         {
-            var dmSpace = "SimulatorIntegrationSpace"; // TODO: this will be in CDF space
-            var dmSimulatorIntegrationExternalId = "SimulatorIntegration";
-            var dmSimulatorExternalId = "Simulator";
             var heartbeat = new RawPropertyValue<long>() {
                 Value = DateTime.UtcNow.ToUnixTimeMilliseconds()
             };
             var initData = new StandardInstanceWriteData() {
                 { "simulator", new DirectRelationIdentifier() {
                     ExternalId = update.Simulator,
-                    Space = dmSpace
+                    Space = SimulatorIntegrationDms.Space
                 }},
                 { SimulatorIntegrationSequenceRows.DataSetId, new RawPropertyValue<long?>() {
                     Value = update.DataSetId,
@@ -55,19 +50,19 @@ namespace Cognite.Simulator.Extensions
                 }},
             };
             var heartbeatOnly = new StandardInstanceWriteData() {
-                { "heartbeat", heartbeat }
+                { SimulatorIntegrationSequenceRows.Heartbeat, heartbeat }
             };
             var simIntegrationProps = init ? initData : heartbeatOnly;
             var instances = new List<BaseInstanceWrite>() {
                 new NodeWrite() {
                     ExternalId = update.ConnectorName,
-                    Space = dmSpace,
+                    Space = SimulatorIntegrationDms.Space,
                     Sources = new List<InstanceData>() {
                         new InstanceData<StandardInstanceWriteData>
                         {
                             Source = new ContainerIdentifier() {
-                                ExternalId = dmSimulatorIntegrationExternalId,
-                                Space = dmSpace
+                                ExternalId = SimulatorIntegrationDms.SimulatorIntegrationContainer,
+                                Space = SimulatorIntegrationDms.Space
                             },
                             Properties = simIntegrationProps
                         }
@@ -82,13 +77,13 @@ namespace Cognite.Simulator.Extensions
                 };
                 instances.Add(new NodeWrite() {
                     ExternalId = update.Simulator,
-                    Space = dmSpace,
+                    Space = SimulatorIntegrationDms.Space,
                     Sources = new List<InstanceData>() {
                         new InstanceData<StandardInstanceWriteData>
                         {
                             Source = new ContainerIdentifier() {
-                                ExternalId = dmSimulatorExternalId,
-                                Space = dmSpace
+                                ExternalId = SimulatorIntegrationDms.SimulatorContainer,
+                                Space = SimulatorIntegrationDms.Space
                             },
                             Properties = simulatorProps
                         }

--- a/Cognite.Simulator.Extensions/ModelExtensions.cs
+++ b/Cognite.Simulator.Extensions/ModelExtensions.cs
@@ -40,19 +40,19 @@ namespace Cognite.Simulator.Extensions
                     ExternalId = update.Simulator,
                     Space = dmSpace
                 }},
-                { "dataSetId", new RawPropertyValue<long?>() {
+                { SimulatorIntegrationSequenceRows.DataSetId, new RawPropertyValue<long?>() {
                     Value = update.DataSetId,
                 }},
-                { "connectorVersion", new RawPropertyValue<string>() {
+                { SimulatorIntegrationSequenceRows.ConnectorVersion, new RawPropertyValue<string>() {
                     Value = update.ConnectorVersion
                 }},
-                { "heartbeat", heartbeat },
-                { "simulatorVersion", new RawPropertyValue<string>() {
+                { SimulatorIntegrationSequenceRows.Heartbeat, heartbeat },
+                { SimulatorIntegrationSequenceRows.SimulatorVersion, new RawPropertyValue<string>() {
                     Value = update.SimulatorVersion,
                 }},
-                // { "simulatorApiEnabled", new RawPropertyValue<bool>() {
-                //     Value = update.SimulatorApiEnabled
-                // }},
+                { SimulatorIntegrationSequenceRows.SimulatorsApiEnabled, new RawPropertyValue<bool>() {
+                    Value = update.SimulatorApiEnabled
+                }},
             };
             var heartbeatOnly = new StandardInstanceWriteData() {
                 { "heartbeat", heartbeat }

--- a/Cognite.Simulator.Extensions/ModelExtensions.cs
+++ b/Cognite.Simulator.Extensions/ModelExtensions.cs
@@ -16,6 +16,19 @@ namespace Cognite.Simulator.Extensions
     {
         /// <summary>
         /// Update the simulator integration data model with the connector heartbeat (last time seen)
+        /// This requires a SimulatorIntegration datamodel in SimulatorIntegrationSpace:
+        /// type Simulator @view(version: "1") {
+        ///     name: String!
+        ///     description: String
+        /// }
+        /// type SimulatorIntegration @view(version: "1") {
+        ///     simulator: Simulator
+        ///     dataSetId: Int64
+        ///     connectorVersion: String!
+        ///     simulatorVersion: String!
+        ///     heartbeat: Int64
+        ///     apiEnabled: Boolean
+        /// }
         /// </summary>
         /// <param name="models">CDF data models</param>
         /// <param name="init">If init, upsert all properties, otherwise only heartbeat</param>

--- a/Cognite.Simulator.Extensions/ModelExtensions.cs
+++ b/Cognite.Simulator.Extensions/ModelExtensions.cs
@@ -27,6 +27,10 @@ namespace Cognite.Simulator.Extensions
             SimulatorIntegrationUpdate update,
             CancellationToken token)
         {
+            if (update == null)
+            {
+                throw new ArgumentNullException(nameof(update));
+            }
             var heartbeat = new RawPropertyValue<long>() {
                 Value = DateTime.UtcNow.ToUnixTimeMilliseconds()
             };

--- a/Cognite.Simulator.Extensions/ModelExtensions.cs
+++ b/Cognite.Simulator.Extensions/ModelExtensions.cs
@@ -20,51 +20,86 @@ namespace Cognite.Simulator.Extensions
         /// Update the simulator integration data model with the connector heartbeat (last time seen)
         /// </summary>
         /// <param name="models">CDF data models</param>
+        /// <param name="init">If init, upsert all properties, otherwise only heartbeat</param>
         /// <param name="update">Data to be updated</param>
         /// <param name="token">Cancellation token</param>
         public static async Task UpdateSimulatorIntegrationsHeartbeat(
             this DataModelsResource models,
+            bool init,
             SimulatorIntegrationUpdate update,
             CancellationToken token)
         {
-            await models.UpsertInstances(new InstanceWriteRequest() {
-                    Items = new List<BaseInstanceWrite>() {
-                        new NodeWrite() {
-                            ExternalId = update.ConnectorName,
-                            Space = "SimulatorSpace", // TODO: this will be in CDF space
-                            Sources = new List<InstanceData>() {
-                                new InstanceData<StandardInstanceWriteData>
-                                {
-                                    Source = new ContainerIdentifier() {
-                                        ExternalId = "SimulatorIntegration",
-                                        Space = "SimulatorSpace"
-                                    },
-                                    Properties = new StandardInstanceWriteData
-                                    {
-                                        { "simulator", new DirectRelationIdentifier() {
-                                            ExternalId = update.Simulator,
-                                            Space = "SimulatorSpace"
-                                        }},
-                                        { "dataSetId", new RawPropertyValue<long?>() {
-                                            Value = update.DataSetId,
-                                        }},
-                                        { "connectorVersion", new RawPropertyValue<string>() {
-                                            Value = update.ConnectorVersion
-                                        }},
-                                        { "heartbeat", new RawPropertyValue<long>() {
-                                            Value = DateTime.UtcNow.ToUnixTimeMilliseconds()
-                                        }},
-                                        { "simulatorVersion", new RawPropertyValue<string>() {
-                                            Value = update.SimulatorVersion,
-                                        }},
-                                        // { "simulatorApiEnabled", new RawPropertyValue<bool>() {
-                                        //     Value = update.SimulatorApiEnabled
-                                        // }},
-                                    },
-                                }
+            var dmSpace = "SimulatorIntegrationSpace"; // TODO: this will be in CDF space
+            var dmSimulatorIntegrationExternalId = "SimulatorIntegration";
+            var dmSimulatorExternalId = "Simulator";
+            var heartbeat = new RawPropertyValue<long>() {
+                Value = DateTime.UtcNow.ToUnixTimeMilliseconds()
+            };
+            var initData = new StandardInstanceWriteData() {
+                { "simulator", new DirectRelationIdentifier() {
+                    ExternalId = update.Simulator,
+                    Space = dmSpace
+                }},
+                { "dataSetId", new RawPropertyValue<long?>() {
+                    Value = update.DataSetId,
+                }},
+                { "connectorVersion", new RawPropertyValue<string>() {
+                    Value = update.ConnectorVersion
+                }},
+                { "heartbeat", heartbeat },
+                { "simulatorVersion", new RawPropertyValue<string>() {
+                    Value = update.SimulatorVersion,
+                }},
+                // { "simulatorApiEnabled", new RawPropertyValue<bool>() {
+                //     Value = update.SimulatorApiEnabled
+                // }},
+            };
+            var heartbeatOnly = new StandardInstanceWriteData() {
+                { "heartbeat", heartbeat }
+            };
+            var simIntegrationProps = init ? initData : heartbeatOnly;
+            var instances = new List<BaseInstanceWrite>() {
+                new NodeWrite() {
+                    ExternalId = update.ConnectorName,
+                    Space = dmSpace,
+                    Sources = new List<InstanceData>() {
+                        new InstanceData<StandardInstanceWriteData>
+                        {
+                            Source = new ContainerIdentifier() {
+                                ExternalId = dmSimulatorIntegrationExternalId,
+                                Space = dmSpace
                             },
+                            Properties = simIntegrationProps
                         }
-                }}, token).ConfigureAwait(false);
+                    },
+                }
+            };
+            if (init) {
+                var simulatorProps = new StandardInstanceWriteData() {
+                    { "name", new RawPropertyValue<string>() {
+                        Value = update.Simulator
+                    }}
+                };
+                instances.Add(new NodeWrite() {
+                    ExternalId = update.Simulator,
+                    Space = dmSpace,
+                    Sources = new List<InstanceData>() {
+                        new InstanceData<StandardInstanceWriteData>
+                        {
+                            Source = new ContainerIdentifier() {
+                                ExternalId = dmSimulatorExternalId,
+                                Space = dmSpace
+                            },
+                            Properties = simulatorProps
+                        }
+                    }
+                });
+            }
+            await models.UpsertInstances(
+                new InstanceWriteRequest() {
+                    Items = instances
+                }, token
+            ).ConfigureAwait(false);
         }
     }
 }

--- a/Cognite.Simulator.Extensions/ModelExtensions.cs
+++ b/Cognite.Simulator.Extensions/ModelExtensions.cs
@@ -1,0 +1,70 @@
+﻿using Cognite.Extensions;
+using Cognite.Extractor.Common;
+using CogniteSdk;
+using CogniteSdk.Beta.DataModels;
+using CogniteSdk.Resources.Beta;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.Simulator.Extensions
+{
+    /// <summary>
+    /// Class containing extensions to the CDF DataModel instances with utility methods
+    /// for simulator integrations
+    /// </summary>
+    public static class ModelInstancesExtensions
+    {
+        /// <summary>
+        /// Update the simulator integration data model with the connector heartbeat (last time seen)
+        /// </summary>
+        /// <param name="models">CDF data models</param>
+        /// <param name="update">Data to be updated</param>
+        /// <param name="token">Cancellation token</param>
+        public static async Task UpdateSimulatorIntegrationsHeartbeat(
+            this DataModelsResource models,
+            SimulatorIntegrationUpdate update,
+            CancellationToken token)
+        {
+            await models.UpsertInstances(new InstanceWriteRequest() {
+                    Items = new List<BaseInstanceWrite>() {
+                        new NodeWrite() {
+                            ExternalId = update.ConnectorName,
+                            Space = "SimulatorSpace", // TODO: this will be in CDF space
+                            Sources = new List<InstanceData>() {
+                                new InstanceData<StandardInstanceWriteData>
+                                {
+                                    Source = new ContainerIdentifier() {
+                                        ExternalId = "SimulatorIntegration",
+                                        Space = "SimulatorSpace"
+                                    },
+                                    Properties = new StandardInstanceWriteData
+                                    {
+                                        { "simulator", new DirectRelationIdentifier() {
+                                            ExternalId = update.Simulator,
+                                            Space = "SimulatorSpace"
+                                        }},
+                                        { "dataSetId", new RawPropertyValue<long?>() {
+                                            Value = update.DataSetId,
+                                        }},
+                                        { "connectorVersion", new RawPropertyValue<string>() {
+                                            Value = update.ConnectorVersion
+                                        }},
+                                        { "heartbeat", new RawPropertyValue<long>() {
+                                            Value = DateTime.UtcNow.ToUnixTimeMilliseconds()
+                                        }},
+                                        { "simulatorVersion", new RawPropertyValue<string>() {
+                                            Value = update.SimulatorVersion,
+                                        }},
+                                        // { "simulatorApiEnabled", new RawPropertyValue<bool>() {
+                                        //     Value = update.SimulatorApiEnabled
+                                        // }},
+                                    },
+                                }
+                            },
+                        }
+                }}, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/Cognite.Simulator.Tests/ExtensionsTests/DataModelsTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/DataModelsTest.cs
@@ -1,0 +1,102 @@
+﻿using CogniteSdk;
+using Cognite.Simulator.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+using Xunit;
+using Cognite.Extractor.Common;
+using CogniteSdk.Beta.DataModels;
+using System.Collections.Generic;
+
+namespace Cognite.Simulator.Tests.ExtensionsTests
+{
+    public class DataModelsTest
+    {
+        [Fact]
+        [Trait("Category", "DataModels")]
+        public async Task TestUpdateSimulatorIntegrationsHeartbeat()
+        {
+            const string connectorName = "integration-tests-connector";
+            const string simulatorName = "TestHeartbeatSimulator";
+            const long dataSetId = CdfTestClient.TestDataset;
+            var services = new ServiceCollection();
+            services.AddCogniteTestClient();
+
+            using var provider = services.BuildServiceProvider();
+            var cdf = provider.GetRequiredService<Client>();
+            var dataModels = cdf.Beta.DataModels;
+
+            string? externalIdToDelete = null;
+            try
+            {
+                var now = DateTime.UtcNow.ToUnixTimeMilliseconds();
+
+                // Update the model instance with connector heartbeat
+                await dataModels.UpdateSimulatorIntegrationsHeartbeat(
+                    true,
+                    new SimulatorIntegrationUpdate
+                    {
+                        Simulator = simulatorName,
+                        DataSetId = dataSetId,
+                        ConnectorName = connectorName,
+                        ConnectorVersion = "1.0.0",
+                        SimulatorVersion = "1.2.3",
+                    },
+                    CancellationToken.None).ConfigureAwait(false);
+
+                // Verify that the model instance was updated correctly
+                var ids = new[] {
+                    new InstanceIdentifier(InstanceType.node, SimulatorIntegrationDms.Space, connectorName)
+                };
+                var result = await dataModels.RetrieveInstances<StandardInstanceData>(new InstancesRetrieve
+                {
+                    Sources = new[]
+                    {
+                        new InstanceSource
+                        {
+                            Source = new ViewIdentifier(
+                                SimulatorIntegrationDms.Space,
+                                SimulatorIntegrationDms.SimulatorIntegrationContainer,
+                                SimulatorIntegrationDms.ViewVersion
+                            ),
+                        }
+                    },
+                    Items = ids,
+                    IncludeTyping = true
+                }, CancellationToken.None).ConfigureAwait(false);
+
+                Assert.Equal(result.Items.Count(), 1);
+                var instance = result.Items.First();
+                var instanceViewAndVersion = SimulatorIntegrationDms.SimulatorIntegrationContainer + "/" + SimulatorIntegrationDms.ViewVersion;
+                var instanceData = result.Items.First().Properties[SimulatorIntegrationDms.Space][instanceViewAndVersion];
+                externalIdToDelete = instance.ExternalId;
+
+                var datasetIdRes = instanceData["dataSetId"] as RawPropertyValue<double>;
+                var heartbeatRes = instanceData["heartbeat"] as RawPropertyValue<double>;
+                var apiEnabledRes = instanceData["apiEnabled"] as RawPropertyValue<bool>;
+                var connectorVersionRes = instanceData["connectorVersion"] as RawPropertyValue<string>;
+                var simulatorVersionRes = instanceData["simulatorVersion"] as RawPropertyValue<string>;
+
+                Assert.Equal(connectorName, instance.ExternalId);
+                Assert.Equal(dataSetId, datasetIdRes?.Value);
+                Assert.False(apiEnabledRes?.Value);
+                Assert.True(heartbeatRes?.Value >= now);
+                Assert.Equal("1.0.0", connectorVersionRes?.Value);
+                Assert.Equal("1.2.3", simulatorVersionRes?.Value);
+            }
+            finally
+            {
+                // Cleanup created damta model instances
+                if (externalIdToDelete != null)
+                {
+                    await dataModels.DeleteInstances(new List<InstanceIdentifier> {
+                        new InstanceIdentifier(InstanceType.node, SimulatorIntegrationDms.Space, externalIdToDelete),
+                        new InstanceIdentifier(InstanceType.node, SimulatorIntegrationDms.Space, simulatorName)
+                    }, CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
@@ -129,7 +129,9 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 new ConnectorConfig
                 {
                     NamePrefix = "Test Connector",
-                    AddMachineNameSuffix = false
+                    AddMachineNameSuffix = false,
+                    UseDataModelsApi = true,
+                    UseSimulatorsApi = false,
                 },
                 new List<SimulatorConfig>
                 {

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
@@ -111,6 +111,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 NamePrefix = "scheduler-test-connector",
                 AddMachineNameSuffix = false,
                 UseSimulatorsApi = true,
+                UseDataModelsApi = true,
                 SchedulerUpdateInterval = 2,
             });
             services.AddSingleton<SampleSimulationScheduler>();

--- a/Cognite.Simulator.Utils/Configuration.cs
+++ b/Cognite.Simulator.Utils/Configuration.cs
@@ -125,6 +125,12 @@ namespace Cognite.Simulator.Utils
         public bool UseSimulatorsApi { get; set; }
 
         /// <summary>
+        /// If <c>true</c>, the connector will use Cognite's Data Models API (requires enabling
+        /// capabilities in CDF). Else, the connector will use only core CDF resources (e.g. sequences)
+        /// </summary>
+        public bool UseDataModelsApi { get; set; }
+
+        /// <summary>
         /// Returns the connector name, composed of the configured prefix and suffix
         /// </summary>
         /// <returns>Connector name</returns>

--- a/Cognite.Simulator.Utils/ConnectorBase.cs
+++ b/Cognite.Simulator.Utils/ConnectorBase.cs
@@ -202,8 +202,8 @@ namespace Cognite.Simulator.Utils
                         update,
                         token).ConfigureAwait(false);
 
-                    await UpdateIntegrationModel(init, token).ConfigureAwait(false);
                 }
+                await UpdateIntegrationModel(init, token).ConfigureAwait(false);
             }
             catch (SimulatorIntegrationSequenceException e)
             {

--- a/Cognite.Simulator.Utils/ConnectorBase.cs
+++ b/Cognite.Simulator.Utils/ConnectorBase.cs
@@ -201,6 +201,8 @@ namespace Cognite.Simulator.Utils
                         init,
                         update,
                         token).ConfigureAwait(false);
+
+                    await UpdateIntegrationModel(init, token).ConfigureAwait(false);
                 }
             }
             catch (SimulatorIntegrationSequenceException e)
@@ -213,6 +215,7 @@ namespace Cognite.Simulator.Utils
         /// Update the heartbeat, data set id and connector version in CDF.
         /// </summary>
         private async Task UpdateIntegrationModel(
+            bool init,
             CancellationToken token)
         {
             var models = Cdf.CogniteClient.Beta.DataModels;
@@ -229,7 +232,7 @@ namespace Cognite.Simulator.Utils
                         SimulatorApiEnabled = ApiEnabled()
                     };
 
-                await models.UpdateSimulatorIntegrationsHeartbeat(update, token).ConfigureAwait(false);
+                await models.UpdateSimulatorIntegrationsHeartbeat(init, update, token).ConfigureAwait(false);
             }
         }
 
@@ -248,8 +251,6 @@ namespace Cognite.Simulator.Utils
                     .ConfigureAwait(false);
                 _logger.LogDebug("Updating connector heartbeat");
                 await UpdateIntegrationRows(false, token)
-                    .ConfigureAwait(false);
-                await UpdateIntegrationModel(token)
                     .ConfigureAwait(false);
             }
         }

--- a/Cognite.Simulator.Utils/ConnectorBase.cs
+++ b/Cognite.Simulator.Utils/ConnectorBase.cs
@@ -215,7 +215,7 @@ namespace Cognite.Simulator.Utils
                         _simulatorSequenceIds[simulator.Name],
                         init,
                         update,
-                        token).ConfigureAwait(false);                    
+                        token).ConfigureAwait(false);
                 }
             }
             catch (SimulatorIntegrationSequenceException e)


### PR DESCRIPTION
This feature requires a SimulatorIntegration model in SimulatorIntegrationSpace:
```
type Simulator @view(version: "1") {
    name: String!
    description: String
}

type SimulatorIntegration @view(version: "1") {
    simulator: Simulator
    dataSetId: Int64
    connectorVersion: String!
    simulatorVersion: String!
    heartbeat: Int64
    apiEnabled: Boolean
}
```

And a boolean feature flag in the config.yaml:
```
connector:
  use-data-models-api: true
```

Example on DWSIM:
![Screenshot 2023-07-24 at 12 35 40](https://github.com/cognitedata/dotnet-simulator-utils/assets/10908415/bd01d7d5-4273-4276-a2f2-83b930462d36)

