### PR TITLE
Add support for other OSs

### DIFF
--- a/Cognite.Simulator.Utils/Automation/AutomationUtils.cs
+++ b/Cognite.Simulator.Utils/Automation/AutomationUtils.cs
@@ -53,7 +53,7 @@ namespace Cognite.Simulator.Utils.Automation
                 Server = ActivateAutomationServer();
             } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                // For now this is enough, to run this on Linux
+                // For now this is enough to run this on Linux
                 Server = null;
             }
             else

--- a/Cognite.Simulator.Utils/Automation/AutomationUtils.cs
+++ b/Cognite.Simulator.Utils/Automation/AutomationUtils.cs
@@ -51,6 +51,10 @@ namespace Cognite.Simulator.Utils.Automation
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Server = ActivateAutomationServer();
+            } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // For now this is enough, to run this on Linux
+                Server = null;
             }
             else
             {


### PR DESCRIPTION
This is required to get the DWSIM connector to work inside a unix docker container