### PR TITLE
Allow file removal to be overridden

### DIFF
--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -82,7 +82,7 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         /// <param name="simulator">Simulator name</param>
         /// <param name="modelName">Model name</param>
-        protected void RemoveLocalFiles(string simulator, string modelName)
+        protected virtual void RemoveLocalFiles(string simulator, string modelName)
         {
             var modelVersions = State.Values
                 .Where(f => !string.IsNullOrEmpty(f.FilePath)


### PR DESCRIPTION
Need a bit more control over which exact file to delete in the GAP connector, specifically speaking, need to delete some additional .vlp files.

https://cognitedata.atlassian.net/browse/POFSP-73?atlOrigin=eyJpIjoiY2QyNTRlYWFiNTc0NDk5Y2JmMzc3ZGYyMDM1NjYyN2QiLCJwIjoiaiJ9