### PR TITLE
[tech dept] Use robust server-side filters

### DIFF
--- a/Cognite.Simulator.Extensions/Cognite.Simulator.Extensions.csproj
+++ b/Cognite.Simulator.Extensions/Cognite.Simulator.Extensions.csproj
@@ -21,8 +21,8 @@
     <None Include="..\LICENSE" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup> 
   <ItemGroup>
-    <!-- <PackageReference Include="Cognite.Extensions" Version="1.18.1" /> -->
-    <ProjectReference Include="..\..\dotnet-extractor-utils\Cognite.Extensions\Cognite.Extensions.csproj" />
+    <PackageReference Include="Cognite.Extensions" Version="1.20.0" />
+    <!-- <ProjectReference Include="..\..\dotnet-extractor-utils\Cognite.Extensions\Cognite.Extensions.csproj" /> -->
   </ItemGroup> 
 
 </Project>

--- a/Cognite.Simulator.Extensions/Cognite.Simulator.Extensions.csproj
+++ b/Cognite.Simulator.Extensions/Cognite.Simulator.Extensions.csproj
@@ -21,8 +21,8 @@
     <None Include="..\LICENSE" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup> 
   <ItemGroup>
-    <PackageReference Include="Cognite.Extensions" Version="1.18.1" />
-    <!-- <ProjectReference Include="..\..\dotnet-extractor-utils\Cognite.Extensions\Cognite.Extensions.csproj" /> -->
+    <!-- <PackageReference Include="Cognite.Extensions" Version="1.18.1" /> -->
+    <ProjectReference Include="..\..\dotnet-extractor-utils\Cognite.Extensions\Cognite.Extensions.csproj" />
   </ItemGroup> 
 
 </Project>

--- a/Cognite.Simulator.Tests/SeedData.cs
+++ b/Cognite.Simulator.Tests/SeedData.cs
@@ -145,13 +145,13 @@ namespace Cognite.Simulator.Tests
                 {
                     Enabled = false,
                 },
-                InputConstants = new List<InputConstants>(),
+                InputConstants = new List<SimulatorRoutineRevisionInputConstants>(),
                 InputTimeseries = new List<SimulatorRoutineRevisionInputTimeseries>(),
                 OutputTimeseries = new List<SimulatorRoutineRevisionOutputTimeseries>(),
             },
             ExternalId = "Test Scheduled Routine - 2",
             RoutineExternalId = $"Test Scheduled Routine - 1",
-            Script = new List<SimulatorRoutineRevisionStage>(),
+            Script = new List<SimulatorRoutineRevisionScriptStage>(),
         };
 
         public static SimulatorRoutineCreateCommandItem SimulatorRoutineCreateScheduled = new SimulatorRoutineCreateCommandItem()
@@ -195,8 +195,8 @@ namespace Cognite.Simulator.Tests
                     SlopeThreshold = -3.0,
                 },
                 // TODO rename type to SimulatorRoutineRevisionInputConstant type
-                InputConstants = new List<InputConstants>() {
-                    new InputConstants() {
+                InputConstants = new List<SimulatorRoutineRevisionInputConstants>() {
+                    new SimulatorRoutineRevisionInputConstants() {
                         SaveTimeseriesExternalId = "SimConnect-IntegrationTests-IC1-SampledSsd",
                         Value = "42",
                         Unit = "STB/MMscf",
@@ -204,7 +204,7 @@ namespace Cognite.Simulator.Tests
                         Name = "Input Constant 1",
                         ReferenceId = "IC1",
                     },
-                    new InputConstants() {
+                    new SimulatorRoutineRevisionInputConstants() {
                         SaveTimeseriesExternalId = "SimConnect-IntegrationTests-IC2-SampledSsd",
                         Value = "100",
                         Unit = "STB/MMscf",
@@ -226,8 +226,8 @@ namespace Cognite.Simulator.Tests
             },
             ExternalId = "Test Routine with Input Constants - 1",
             RoutineExternalId = "Test Routine with Input Constants",
-            Script = new List<SimulatorRoutineRevisionStage>() {
-                new SimulatorRoutineRevisionStage() {
+            Script = new List<SimulatorRoutineRevisionScriptStage>() {
+                new SimulatorRoutineRevisionScriptStage() {
                     Order = 1,
                     Description = "Set simulation inputs",
                     Steps = new List<SimulatorRoutineRevisionScriptStep>() {
@@ -249,7 +249,7 @@ namespace Cognite.Simulator.Tests
                         },
                     },
                 },
-                new SimulatorRoutineRevisionStage() {
+                new SimulatorRoutineRevisionScriptStage() {
                     Order = 2,
                     Description = "Perform simulation",
                     Steps = new List<SimulatorRoutineRevisionScriptStep>() {
@@ -262,7 +262,7 @@ namespace Cognite.Simulator.Tests
                         },
                     },
                 },
-                new SimulatorRoutineRevisionStage() {
+                new SimulatorRoutineRevisionScriptStage() {
                     Order = 3,
                     Description = "Get output time series",
                     Steps = new List<SimulatorRoutineRevisionScriptStep>() {
@@ -318,7 +318,7 @@ namespace Cognite.Simulator.Tests
                     VarThreshold = 1.0,
                     SlopeThreshold = -3.0,
                 },
-                InputConstants = new List<InputConstants>(),
+                InputConstants = new List<SimulatorRoutineRevisionInputConstants>(),
                 OutputTimeseries = new List<SimulatorRoutineRevisionOutputTimeseries>() {
                     new SimulatorRoutineRevisionOutputTimeseries() {
                         Name = "Output Test 1",
@@ -343,8 +343,8 @@ namespace Cognite.Simulator.Tests
             },
             ExternalId = "Test Routine with Input Constants - 1",
             RoutineExternalId = "Test Routine with Input Constants",
-            Script = new List<SimulatorRoutineRevisionStage>() {
-                new SimulatorRoutineRevisionStage() {
+            Script = new List<SimulatorRoutineRevisionScriptStage>() {
+                new SimulatorRoutineRevisionScriptStage() {
                     Order = 1,
                     Description = "Set simulation inputs",
                     Steps = new List<SimulatorRoutineRevisionScriptStep>() {
@@ -358,7 +358,7 @@ namespace Cognite.Simulator.Tests
                         },
                     },
                 },
-                new SimulatorRoutineRevisionStage() {
+                new SimulatorRoutineRevisionScriptStage() {
                     Order = 2,
                     Description = "Perform simulation",
                     Steps = new List<SimulatorRoutineRevisionScriptStep>() {
@@ -371,7 +371,7 @@ namespace Cognite.Simulator.Tests
                         },
                     },
                 },
-                new SimulatorRoutineRevisionStage() {
+                new SimulatorRoutineRevisionScriptStage() {
                     Order = 3,
                     Description = "Get output time series",
                     Steps = new List<SimulatorRoutineRevisionScriptStep>() {

--- a/Cognite.Simulator.Tests/SeedData.cs
+++ b/Cognite.Simulator.Tests/SeedData.cs
@@ -194,7 +194,6 @@ namespace Cognite.Simulator.Tests
                     VarThreshold = 1.0,
                     SlopeThreshold = -3.0,
                 },
-                // TODO rename type to SimulatorRoutineRevisionInputConstant type
                 InputConstants = new List<SimulatorRoutineRevisionInputConstants>() {
                     new SimulatorRoutineRevisionInputConstants() {
                         SaveTimeseriesExternalId = "SimConnect-IntegrationTests-IC1-SampledSsd",

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
@@ -82,8 +82,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     {
                         Filter = new SimulationRunFilter
                         {
-                            // TODO: apply new filters
+                            SimulatorIntegrationExternalIds = new List<string> { "scheduler-test-connector" },
+                            SimulatorExternalIds = new List<string> { "PROSPER" },
                             Status = SimulationRunStatus.ready,
+                            ModelRevisionExternalIds = new List<string> { "PROSPER-Connector_Test_Model-2" },
                         },
                         Sort = new List<SimulatorSortItem>
                         {
@@ -93,14 +95,14 @@ namespace Cognite.Simulator.Tests.UtilsTests
                                 Order = SimulatorSortOrder.desc,
                             }
                         },
+                        Limit = 10,
                     }, source.Token).ConfigureAwait(false);
                 Assert.NotEmpty(simRuns.Items);
 
                 // check if there are any simulation runs in the time span of the test
                 // with the run type set to scheduled
                 var latestEventsFiltered = simRuns.Items.Where(
-                    r => r.CreatedTime >= testStartTimeMillis &&
-                    r.SimulatorIntegrationExternalId == "scheduler-test-connector" && r.ModelRevisionExternalId == "PROSPER-Connector_Test_Model-2"
+                    r => r.CreatedTime >= testStartTimeMillis && r.RunType == SimulationRunType.scheduled
                 );
                 Assert.NotEmpty(latestEventsFiltered);
                 Assert.Contains(latestEventsFiltered, e => e.RunType == SimulationRunType.scheduled);

--- a/Cognite.Simulator.Utils/Cognite.Simulator.Utils.csproj
+++ b/Cognite.Simulator.Utils/Cognite.Simulator.Utils.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Cognite.ExtractorUtils" Version="1.18.1" /> -->
-    <ProjectReference Include="..\..\dotnet-extractor-utils\ExtractorUtils\ExtractorUtils.csproj" />
+    <PackageReference Include="Cognite.ExtractorUtils" Version="1.20.0" />
+    <!-- <ProjectReference Include="..\..\dotnet-extractor-utils\ExtractorUtils\ExtractorUtils.csproj" /> -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/Cognite.Simulator.Utils/Cognite.Simulator.Utils.csproj
+++ b/Cognite.Simulator.Utils/Cognite.Simulator.Utils.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.ExtractorUtils" Version="1.18.1" />
-    <!-- <ProjectReference Include="..\..\dotnet-extractor-utils\ExtractorUtils\ExtractorUtils.csproj" /> -->
+    <!-- <PackageReference Include="Cognite.ExtractorUtils" Version="1.18.1" /> -->
+    <ProjectReference Include="..\..\dotnet-extractor-utils\ExtractorUtils\ExtractorUtils.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
@@ -207,7 +207,7 @@ namespace Cognite.Simulator.Utils
                 throw new ArgumentNullException(nameof(config));
             }
 
-            var routineRevision = await CdfSimulatorResources.RetrieveSimulatorModelRevisionsAsync(
+            var routineRevision = await CdfSimulatorResources.RetrieveSimulatorRoutineRevisionsAsync(
                 new List<CogniteSdk.Identity> { new CogniteSdk.Identity(long.Parse(state.Id)) },
                 token
             ).ConfigureAwait(false);
@@ -273,9 +273,9 @@ namespace Cognite.Simulator.Utils
                 {
                     Filter = new SimulatorRoutineRevisionFilter()
                     {
-                        // TODO filter by created time, simulatorIntegrationExternalIds
+                        // TODO filter by created time, simulatorExternalIds, simulatorIntegrationExternalIds
                         // CreatedTime = new CogniteSdk.TimeRange() {  Min = _libState.DestinationExtractedRange.Last.ToUnixTimeMilliseconds() + 1 },
-                        SimulatorExternalIds = _simulators.Select(s => s.Name).ToList(),
+                        //SimulatorExternalIds = _simulators.Select(s => s.Name).ToList(),
                     }
                 },
                 token

--- a/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
@@ -207,18 +207,12 @@ namespace Cognite.Simulator.Utils
                 throw new ArgumentNullException(nameof(config));
             }
 
-            // TODO: get routine revision by id
-            var routineRevisions = await CdfSimulatorResources.ListSimulatorRoutineRevisionsAsync(
-                new CogniteSdk.Alpha.SimulatorRoutineRevisionQuery
-                {
-                    Filter = new CogniteSdk.Alpha.SimulatorRoutineRevisionFilter
-                    {
-                        RoutineExternalIds = new List<string> { config.CalculationName },
-                    }
-                },
-                token: token).ConfigureAwait(false);
+            var routineRevision = await CdfSimulatorResources.RetrieveSimulatorModelRevisionsAsync(
+                new List<CogniteSdk.Identity> { new CogniteSdk.Identity(long.Parse(state.Id)) },
+                token
+            ).ConfigureAwait(false);
 
-            return routineRevisions.Items.Any(v => v.Id == long.Parse(state.Id));
+            return routineRevision != null;
         }
 
         /// <inheritdoc/>
@@ -279,8 +273,9 @@ namespace Cognite.Simulator.Utils
                 {
                     Filter = new SimulatorRoutineRevisionFilter()
                     {
-                        // TODO filter by created time, simulatorExternalIds, simulatorIntegrationExternalIds
+                        // TODO filter by created time, simulatorIntegrationExternalIds
                         // CreatedTime = new CogniteSdk.TimeRange() {  Min = _libState.DestinationExtractedRange.Last.ToUnixTimeMilliseconds() + 1 },
+                        SimulatorExternalIds = _simulators.Select(s => s.Name).ToList(),
                     }
                 },
                 token

--- a/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
@@ -273,9 +273,9 @@ namespace Cognite.Simulator.Utils
                 {
                     Filter = new SimulatorRoutineRevisionFilter()
                     {
-                        // TODO filter by created time, simulatorExternalIds, simulatorIntegrationExternalIds
+                        // TODO filter by created time, simulatorIntegrationExternalIds
                         // CreatedTime = new CogniteSdk.TimeRange() {  Min = _libState.DestinationExtractedRange.Last.ToUnixTimeMilliseconds() + 1 },
-                        //SimulatorExternalIds = _simulators.Select(s => s.Name).ToList(),
+                        SimulatorExternalIds = _simulators.Select(s => s.Name).ToList(),
                     }
                 },
                 token

--- a/Cognite.Simulator.Utils/FileLibrary.cs
+++ b/Cognite.Simulator.Utils/FileLibrary.cs
@@ -317,7 +317,7 @@ namespace Cognite.Simulator.Utils
                     {   
                         if (_resourceType != SimulatorDataType.ModelFile) {
                             continue; // TODO this is handled by routines now, we don't need to download files
-                            // TODO: this method shouldn't even run for routines (?)
+                            // TODO: make a simpler base class for routines (no file download, only local state, etc)
                         }
                         var fileId = new Identity(file.CdfId);
                         var response = await CdfFiles

--- a/Cognite.Simulator.Utils/FileLibrary.cs
+++ b/Cognite.Simulator.Utils/FileLibrary.cs
@@ -183,11 +183,10 @@ namespace Cognite.Simulator.Utils
             bool onlyLatest,
             CancellationToken token)
         {
-            try
-            {
-                            long createdAfter = 
-                onlyLatest && !_libState.DestinationExtractedRange.IsEmpty ?
-                    _libState.DestinationExtractedRange.Last.ToUnixTimeMilliseconds() : 0;
+            try {
+                long createdAfter = 
+                    onlyLatest && !_libState.DestinationExtractedRange.IsEmpty ?
+                        _libState.DestinationExtractedRange.Last.ToUnixTimeMilliseconds() : 0;
 
                 var simulatorsExternalIds = _simulators.Select(s => s.Name).ToList();
 
@@ -212,7 +211,7 @@ namespace Cognite.Simulator.Utils
                         new SimulatorModelRevisionQuery() {
                             Filter = new SimulatorModelRevisionFilter() {
                                 CreatedTime = new CogniteSdk.TimeRange() {  Min = createdAfter + 1 },
-                                ModelExternalIds = modelExternalIds,  
+                                ModelExternalIds = modelExternalIds,
                             }
                         },
                         token
@@ -237,7 +236,6 @@ namespace Cognite.Simulator.Utils
             {
                 Logger.LogDebug("Failed to fetch model revisions from CDF: {Message}", e.Message);
             }
-
         }
 
         /// <summary>


### PR DESCRIPTION
- got rid of some of the client-side filtering in favour of the new filters/endpoints on the API
- use a newer version of the SDK (includes some class renames)