### PR TITLE
Configuration library clean-up

### DIFF
--- a/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
@@ -375,7 +375,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
     }
 
     public class ConfigurationLibraryTest :
-        ConfigurationLibraryBase<TestConfigurationState, FileStatePoco, SimulationConfigurationWithRoutine>
+        ConfigurationLibraryBase<TestConfigurationState, FileStatePoco>
     {
         public ConfigurationLibraryTest(
             CogniteDestination cdf, 
@@ -401,10 +401,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 },
                 cdf, logger, store)
         {
-        }
-
-        protected override SimulationConfigurationWithRoutine ToType(SimulationConfigurationWithRoutine routine) {
-            return routine;
         }
 
         protected override TestConfigurationState StateFromRoutineRevision(SimulatorRoutineRevision routineRevision, SimulatorRoutine routine)

--- a/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
@@ -375,7 +375,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
     }
 
     public class ConfigurationLibraryTest :
-        ConfigurationLibraryBase<TestConfigurationState, FileStatePoco>
+        ConfigurationLibraryBase<TestConfigurationState, FileStatePoco, SimulationConfigurationWithRoutine>
     {
         public ConfigurationLibraryTest(
             CogniteDestination cdf, 

--- a/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
@@ -174,10 +174,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
             finally
             {
-                // if (Directory.Exists("./configurations"))
-                // {
-                //     Directory.Delete("./configurations", true);
-                // }
                 if (stateConfig != null)
                 {
                     StateUtils.DeleteLocalFile(stateConfig.Location);
@@ -256,10 +252,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
             finally
             {
-                // if (Directory.Exists("./configurations"))
-                // {
-                //     Directory.Delete("./configurations", true);
-                // }
                 if (stateConfig != null)
                 {
                     StateUtils.DeleteLocalFile(stateConfig.Location);
@@ -384,7 +376,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
             base(
                 new FileLibraryConfig
                 {
-                    // FilesDirectory = "./configurations",
                     FilesTable = "ConfigurationFiles",
                     LibraryId = "ConfigurationState",
                     LibraryTable = "Library",

--- a/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileLibraryTest.cs
@@ -339,11 +339,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }, token);
         }
 
-        protected override TestFileState StateFromRoutineRevision(SimulatorRoutineRevision routineRevision, SimulatorRoutine routine)
-        {
-            throw new NotImplementedException();
-        }
-
         protected override TestFileState StateFromModelRevision(SimulatorModelRevision modelRevision, CogniteSdk.Alpha.SimulatorModel model)
         {
             if (modelRevision == null)
@@ -385,12 +380,11 @@ namespace Cognite.Simulator.Tests.UtilsTests
         public ConfigurationLibraryTest(
             CogniteDestination cdf, 
             ILogger<ConfigurationLibraryTest> logger, 
-            FileDownloadClient downloadClient, 
             IExtractionStateStore store = null) : 
             base(
                 new FileLibraryConfig
                 {
-                    FilesDirectory = "./configurations",
+                    // FilesDirectory = "./configurations",
                     FilesTable = "ConfigurationFiles",
                     LibraryId = "ConfigurationState",
                     LibraryTable = "Library",
@@ -405,7 +399,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                         DataSetId = CdfTestClient.TestDataset
                     }
                 },
-                cdf, logger, downloadClient, store)
+                cdf, logger, store)
         {
         }
 
@@ -427,25 +421,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 Deserialized = false,
                 ExternalId = routineRevision.ExternalId,
             };
-        }
-
-        // protected override TestConfigurationState StateFromFile(CogniteSdk.File file)
-        // {
-        //     return new TestConfigurationState(file.ExternalId)
-        //     {
-        //         CdfId = file.Id,
-        //         DataSetId = file.DataSetId,
-        //         CreatedTime = file.CreatedTime,
-        //         UpdatedTime = file.LastUpdatedTime,
-        //         ModelName = file.Metadata[ModelMetadata.NameKey],
-        //         Source = file.Source,
-        //         Deserialized = false
-        //     };
-        // }
-
-        protected override TestConfigurationState StateFromModelRevision(SimulatorModelRevision modelRevision, CogniteSdk.Alpha.SimulatorModel model)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -284,10 +284,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 {
                     Directory.Delete("./files", true);
                 }
-                if (Directory.Exists("./configurations"))
-                {
-                    Directory.Delete("./configurations", true);
-                }
+                // if (Directory.Exists("./configurations"))
+                // {
+                //     Directory.Delete("./configurations", true);
+                // }
                 if (stateConfig != null)
                 {
                     StateUtils.DeleteLocalFile(stateConfig.Location);

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -284,10 +284,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 {
                     Directory.Delete("./files", true);
                 }
-                // if (Directory.Exists("./configurations"))
-                // {
-                //     Directory.Delete("./configurations", true);
-                // }
                 if (stateConfig != null)
                 {
                     StateUtils.DeleteLocalFile(stateConfig.Location);

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
@@ -115,10 +115,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
                         .ConfigureAwait(false);
                 }
                 provider.Dispose(); // Dispose provider to also dispose managed services
-                // if (Directory.Exists("./configurations"))
-                // {
-                //     Directory.Delete("./configurations", true);
-                // }
                 if (stateConfig != null)
                 {
                     StateUtils.DeleteLocalFile(stateConfig.Location);

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
@@ -115,10 +115,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
                         .ConfigureAwait(false);
                 }
                 provider.Dispose(); // Dispose provider to also dispose managed services
-                if (Directory.Exists("./configurations"))
-                {
-                    Directory.Delete("./configurations", true);
-                }
+                // if (Directory.Exists("./configurations"))
+                // {
+                //     Directory.Delete("./configurations", true);
+                // }
                 if (stateConfig != null)
                 {
                     StateUtils.DeleteLocalFile(stateConfig.Location);

--- a/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ConfigurationLibraryBase.cs
@@ -29,6 +29,7 @@ namespace Cognite.Simulator.Utils
     {
         /// <inheritdoc/>
         public Dictionary<string, V> SimulationConfigurations { get; }
+
         private IList<SimulatorConfig> _simulators;
         /// <inheritdoc/>
         protected CogniteSdk.Resources.Alpha.SimulatorsResource CdfSimulatorResources { get; private set; }
@@ -352,11 +353,6 @@ namespace Cognite.Simulator.Utils
         /// Simulation routine
         /// </summary>
         public IEnumerable<CalculationProcedure> Routine { get; set; }
-
-        /// <summary>
-        /// Created time
-        /// </summary>
-        public long CreatedTime { get; set; }
     }
 
     /// <summary>
@@ -719,6 +715,11 @@ namespace Cognite.Simulator.Utils
             Type = CalculationType,
             UserDefinedType = CalcTypeUserDefined
         };
+
+        /// <summary>
+        /// Created time
+        /// </summary>
+        public long CreatedTime { get; set; }
     }
 
     /// <summary>

--- a/Cognite.Simulator.Utils/FileLibrary.cs
+++ b/Cognite.Simulator.Utils/FileLibrary.cs
@@ -10,8 +10,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -107,6 +105,9 @@ namespace Cognite.Simulator.Utils
         /// <param name="token">Cancellation token</param>
         public async Task Init(CancellationToken token)
         {
+            if (_resourceType != SimulatorDataType.ModelFile) {
+                throw new ArgumentException("Only model files are supported");
+            }
             Logger.LogDebug("Ensuring directory to store files exists: {Path}", _modelFolder);
             var dir = Directory.CreateDirectory(_modelFolder);
             _modelFolder = dir.FullName;
@@ -308,10 +309,6 @@ namespace Cognite.Simulator.Utils
                         CogniteTime.FromUnixTimeMilliseconds(file.UpdatedTime).ToISOString());
                     try
                     {   
-                        if (_resourceType != SimulatorDataType.ModelFile) {
-                            continue; // TODO this is handled by routines now, we don't need to download files
-                            // TODO: make a simpler base class for routines (no file download, only local state, etc)
-                        }
                         var fileId = new Identity(file.CdfId);
                         var response = await CdfFiles
                             .DownloadAsync(new[] { fileId }, token)

--- a/Cognite.Simulator.Utils/FileLibrary.cs
+++ b/Cognite.Simulator.Utils/FileLibrary.cs
@@ -160,13 +160,6 @@ namespace Cognite.Simulator.Utils
 
         /// <summary>
         /// Creates a state object of type <typeparamref name="T"/> from a
-        /// CDF file passed as parameter
-        /// </summary>
-        /// <returns>File state object</returns>
-        protected abstract T StateFromRoutineRevision(CogniteSdk.Alpha.SimulatorRoutineRevision routineRevision, CogniteSdk.Alpha.SimulatorRoutine routine);
-
-        /// <summary>
-        /// Creates a state object of type <typeparamref name="T"/> from a
         /// CDF Simulator model revision passed as parameter
         /// </summary>
         /// <param name="modelRevision">CDF Simulator model revision</param>

--- a/Cognite.Simulator.Utils/FileLibrary.cs
+++ b/Cognite.Simulator.Utils/FileLibrary.cs
@@ -173,7 +173,9 @@ namespace Cognite.Simulator.Utils
         /// Build a local state to keep track of what files exist and which ones have
         /// been downloaded.
         /// </summary>
-        private async Task FindFilesByRevisions(
+        /// <param name="onlyLatest">Fetch only the files updated after the latest timestamp in the local store</param>
+        /// <param name="token">Cancellation token</param>
+        private async Task FindFiles(
             bool onlyLatest,
             CancellationToken token)
         {
@@ -230,28 +232,6 @@ namespace Cognite.Simulator.Utils
             {
                 Logger.LogDebug("Failed to fetch model revisions from CDF: {Message}", e.Message);
             }
-        }
-
-        /// <summary>
-        /// Fetch the Files from CDF for the configured simulators and datasets.
-        /// Build a local state to keep track of what files exist and which ones have 
-        /// been downloaded.
-        /// </summary>
-        /// <param name="onlyLatest">Fetch only the files updated after the latest timestamp in the local store</param>
-        /// <param name="token">Cancellation token</param>
-        private async Task FindFiles(
-            bool onlyLatest,
-            CancellationToken token)
-        {
-            if (_resourceType == SimulatorDataType.ModelFile) {
-                // Use the simulator model revisions API
-                await FindFilesByRevisions(onlyLatest, token).ConfigureAwait(false);
-            } else {
-                
-                // throw new Exception("Only model files are supported");
-                // await FindFilesByMetadata(onlyLatest, token).ConfigureAwait(false);
-            }
-            
         }
 
         /// <summary>

--- a/Cognite.Simulator.Utils/LocalLibrary.cs
+++ b/Cognite.Simulator.Utils/LocalLibrary.cs
@@ -1,0 +1,234 @@
+using Cognite.Extractor.Common;
+using Cognite.Extractor.StateStorage;
+using Cognite.Extractor.Utils;
+using Cognite.Simulator.Extensions;
+using CogniteSdk;
+using CogniteSdk.Alpha;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.Simulator.Utils
+{
+    /// <summary>
+    /// Represents a local file library. The library can be configured to fetch files
+    /// associated to a simulator and stored in a CDF dataset (see <seealso cref="SimulatorConfig"/>).
+    /// The files are stored locally at the folder specified in the library configuration (<seealso cref="FileLibraryConfig"/>).
+    /// Files are kept in sync with CDF, so that updates in the remote files are reflected on the local files.
+    /// </summary>
+    /// <typeparam name="T">Type of the state object used in this library</typeparam>
+    /// <typeparam name="U">Type of the data object used to serialize and deserialize state</typeparam>
+    public abstract class LocalLibrary<T, U>
+        where T : FileState
+        where U : FileStatePoco
+    {
+        /// <summary>
+        /// Dictionary holding the file states. The keys are the external ids of the
+        /// CDF files and the values are the state objects of type <typeparamref name="T"/>
+        /// </summary>
+        public Dictionary<string, T> State { get; private set; }
+
+        /// <summary>
+        /// Logger object
+        /// </summary>
+        protected ILogger Logger { get; private set; }
+
+        // Other injected services
+        private readonly FileLibraryConfig _config;
+        // private readonly IList<SimulatorConfig> _simulators;
+        private readonly IExtractionStateStore _store;
+        // private readonly FileDownloadClient _downloadClient;
+
+        // Internal objects
+        private readonly BaseExtractionState _libState;
+        // private readonly SimulatorDataType _resourceType;
+        // private string _modelFolder;
+
+        /// <summary>
+        /// Creates a new instance of this library using the provided parameters.
+        /// These parameters are intended to be injected by using a <see cref="IServiceCollection"/>
+        /// </summary>
+        /// <param name="config">Library configuration</param>
+        /// <param name="logger">Logger</param>
+        /// <param name="store">State store for files state</param>
+        public LocalLibrary(
+            FileLibraryConfig config,
+            ILogger logger,
+            IExtractionStateStore store = null)
+        {
+            _config = config;
+            _store = store;
+            Logger = logger;
+            State = new Dictionary<string, T>();
+            _libState = new BaseExtractionState(_config.LibraryId);
+        }
+        
+        /// <summary>
+        /// Initializes the local file library. Creates the folder, find the files in CDF and restore state.
+        /// </summary>
+        /// <param name="token">Cancellation token</param>
+        public async Task Init(CancellationToken token)
+        {
+
+            if (_store != null)
+            {
+                await _store.RestoreExtractionState(
+                    new Dictionary<string, BaseExtractionState>() { { _config.LibraryId, _libState } },
+                    _config.LibraryTable,
+                    true,
+                    token).ConfigureAwait(false);
+            }
+            
+            FetchRemoteState(token);
+
+            if (_store != null)
+            {
+                await _store.RestoreExtractionState<U, T>(
+                    State,
+                    _config.FilesTable,
+                    (state, poco) =>
+                    {
+                        state.Init(poco);
+                    },
+                    token).ConfigureAwait(false);
+                if (_store is LiteDBStateStore ldbStore)
+                {
+                    HashSet<string> idsToKeep = new HashSet<string>(State.Select(s => s.Value.Id));
+                    var col = ldbStore.Database.GetCollection<FileStatePoco>(_config.FilesTable);
+                    var stateToDelete = col
+                        .Find(s => !idsToKeep.Contains(s.Id))
+                        .ToList();
+                    if (stateToDelete.Any())
+                    {
+                        foreach(var state in stateToDelete)
+                        {
+                            col.Delete(state.Id);
+                        }
+                    }
+                }
+            }
+            Logger.LogInformation("Local state store {Table} initiated. Tracking {Num} files", _config.FilesTable, State.Count);
+        }
+
+        /// <summary>
+        /// Remove the provided file states from the state store
+        /// </summary>
+        /// <param name="states">States to remove</param>
+        /// <param name="token">Cancellation token</param>
+        protected async Task RemoveStates(
+            IEnumerable<T> states,
+            CancellationToken token)
+        {
+            if (states == null || !states.Any())
+            {
+                return;
+            }
+            await _store.DeleteExtractionState(states, _config.FilesTable, token)
+                .ConfigureAwait(false);
+            // await _store
+            //     .RemoveFileStates(_config.FilesTable, states, token)
+            //     .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a list of the tasks performed by this library.
+        /// These include searching and downloading files ans saving state.
+        /// </summary>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>List of tasks</returns>
+        public IEnumerable<Task> GetRunTasks(CancellationToken token)
+        {
+            return new List<Task> { SaveStates(token), FetchAndProcessRemoteState(token) };
+        }
+
+        /// <summary>
+        /// Save periodically the library state (first and last file creation timestamp) and the 
+        /// files state (path to the file stored locally)
+        /// </summary>
+        /// <param name="token">Cancellation token</param>
+        private async Task SaveStates(CancellationToken token)
+        {
+            if (_store == null)
+            {
+                return;
+            }
+            while (!token.IsCancellationRequested)
+            {
+                var waitTask = Task.Delay(TimeSpan.FromSeconds(_config.StateStoreInterval), token);
+                var storeTask = StoreLibraryState(token);
+                await Task.WhenAll(waitTask, storeTask).ConfigureAwait(false);
+            }
+        }
+
+         /// <summary>
+        /// Periodically searches for new files in CDF, in case new ones are found, download them and store locally.
+        /// Files are saved with the internal CDF id as name
+        /// </summary>
+        /// <param name="token">Cancellation token</param>
+        private async Task FetchAndProcessRemoteState(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                string timeRange = _libState.DestinationExtractedRange.IsEmpty ? "Empty" : _libState.DestinationExtractedRange.ToString();
+                Logger.LogDebug("Updating file library. There are currently {Num} files. Extracted range: {TimeRange}",
+                    State.Count,
+                    timeRange
+                    );
+
+
+                FetchRemoteState(token);
+
+                if (State.Any())
+                {
+                    var maxUpdatedMs = State
+                        .Select(s => s.Value.UpdatedTime)
+                        .Max();
+                    var maxUpdatedDt = CogniteTime.FromUnixTimeMilliseconds(maxUpdatedMs);
+                    _libState.UpdateDestinationRange(
+                        maxUpdatedDt,
+                        maxUpdatedDt);
+                }
+
+                await Task
+                    .Delay(TimeSpan.FromSeconds(_config.StateStoreInterval), token)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Process files that have been downloaded. This method should open 
+        /// the file in a simulator, verify that it is valid, extract relevant data
+        /// and ingest it to CDF. 
+        /// </summary>
+        /// <param name="token">Cancellation token</param>
+        protected abstract void FetchRemoteState(CancellationToken token);
+
+        /// <summary>
+        /// Persists the library state from memory to the store
+        /// </summary>
+        /// <param name="token">Cancellation token</param>
+        public async Task StoreLibraryState(CancellationToken token)
+        {
+            if (_store == null)
+            {
+                return;
+            }
+            await _store.StoreExtractionState(
+                new[] { _libState },
+                _config.LibraryTable,
+                token).ConfigureAwait(false);
+            await _store.StoreExtractionState(
+                State.Values,
+                _config.FilesTable,
+                (state) => state.GetPoco(),
+                token).ConfigureAwait(false);
+        }
+    }
+}

--- a/Cognite.Simulator.Utils/SimulationScheduler.cs
+++ b/Cognite.Simulator.Utils/SimulationScheduler.cs
@@ -95,11 +95,11 @@ namespace Cognite.Simulator.Utils
             {
                 var now = DateTime.UtcNow;
                 var eventsToCreate = new List<SimulationEvent>();
-                var configurations = _configLib.SimulationConfigurations;
-                foreach (var configuration in configurations)
+                var configurations = _configLib.SimulationConfigurations.Values
+                    .GroupBy(c => c.CalculationName)
+                    .Select(x => x.OrderByDescending(c => c.CreatedTime).First());
+                foreach (var configObj in configurations)
                 {
-                    var configObj = configuration.Value;
-
                     U configState = _configLib.GetSimulationConfigurationState(
                         configObj.ExternalId
                     );


### PR DESCRIPTION
Configuration library clean-up

- Don't be dependent on FileLibrary, only use local DB state
- remove unused methods
- rename TyTope to LocalConfigurationFromRoutine, make a default implementation for it
- fix potential bug in the scheduler when multiple versions of the routine available