### PR TITLE
Remove sequence based boundary conditions

### DIFF
--- a/Cognite.Simulator.Extensions/SequencesExtensions.cs
+++ b/Cognite.Simulator.Extensions/SequencesExtensions.cs
@@ -18,53 +18,6 @@ namespace Cognite.Simulator.Extensions
     public static class SequencesExtensions
     {
         /// <summary>
-        /// For the specified <paramref name="model"/>, 
-        /// find the sequence rows with the mapping of the model boundary conditions to
-        /// time series external ids.
-        /// </summary>
-        /// <param name="sequences">CDF sequences resource</param>
-        /// <param name="model">Simulator model</param>
-        /// <param name="token">Cancellation token</param>
-        /// <returns>Sequence data (rows) containing the boundary conditions map</returns>
-        /// <exception cref="BoundaryConditionsMapNotFoundException">Thrown when a sequence containing
-        /// the boundary conditions map cannot be found</exception>
-        public static async Task<SequenceData> FindModelBoundaryConditions(
-            this SequencesResource sequences,
-            SimulatorModelInfo model,
-            CancellationToken token)
-        {
-            if (model == null || string.IsNullOrEmpty(model.Name) || string.IsNullOrEmpty(model.Simulator))
-            {
-                throw new ArgumentException("Simulator model should have valid name and simulator properties", nameof(model));
-            }
-            var bcSeqs = await sequences.ListAsync(new SequenceQuery
-            {
-                Filter = new SequenceFilter
-                {
-                    ExternalIdPrefix = $"{model.Simulator}-BC-",
-                    Metadata = new Dictionary<string, string>
-                    {
-                        { ModelMetadata.NameKey, model.Name },
-                        { BaseMetadata.DataTypeKey, BoundaryConditionsMapMetadata.DataType.MetadataValue()}
-                    }
-                },
-            }, token).ConfigureAwait(false);
-            if (!bcSeqs.Items.Any())
-            {
-                // No boundary conditions map defined yet
-                throw new BoundaryConditionsMapNotFoundException(
-                    "Sequence mapping boundary conditions to time series not found in CDF");
-            }
-
-            var bcSeq = bcSeqs.Items.First();
-
-            return await sequences.ListRowsAsync(new SequenceRowQuery
-            {
-                ExternalId = bcSeq.ExternalId
-            }, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Store tabular simulation results as sequences
         /// </summary>
         /// <param name="sequences">CDF Sequence resource</param>

--- a/Cognite.Simulator.Tests/ExtensionsTests/SequencesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/SequencesTest.cs
@@ -13,34 +13,7 @@ using Cognite.Extractor.Common;
 namespace Cognite.Simulator.Tests.ExtensionsTests
 {
     public class SequencesTest
-    {
-        [Fact]
-        public async Task TestFindModelBoundaryConditions()
-        {
-            var services = new ServiceCollection();
-            services.AddCogniteTestClient();
-
-            using var provider = services.BuildServiceProvider();
-            var cdf = provider.GetRequiredService<Client>();
-            var sequences = cdf.Sequences;
-
-            // Assumes this resource exists in the CDF test project
-            var rows = await sequences.FindModelBoundaryConditions(
-                new SimulatorModelInfo
-                {
-                    Simulator = "PROSPER",
-                    Name = "Connector Test Model",
-                },
-                CancellationToken.None).ConfigureAwait(false);
-            Assert.NotEmpty(rows.Columns);
-            Assert.Contains(rows.Columns, c => c.ExternalId == BoundaryConditionsSequenceColumns.Id);
-            Assert.Contains(rows.Columns, c => c.ExternalId == BoundaryConditionsSequenceColumns.TimeSeries);
-            Assert.Contains(rows.Columns, c => c.ExternalId == BoundaryConditionsSequenceColumns.Name);
-            Assert.Contains(rows.Columns, c => c.ExternalId == BoundaryConditionsSequenceColumns.Address);
-            Assert.NotEmpty(rows.Rows);
-            Assert.Equal(4, rows.Rows.First().Values.Count());
-        }
-
+    { 
         [Fact]
         public async Task TestStoreSimulationResults()
         {


### PR DESCRIPTION
- we use to call this function only for Prosper
- we got rid of it in this pr https://github.com/cognitedata/simconnect-dotnet/pull/174/files