### PR TITLE
Tests, run them against charts-azuredev project

### DIFF
--- a/Cognite.Simulator.Tests/CdfTestClient.cs
+++ b/Cognite.Simulator.Tests/CdfTestClient.cs
@@ -20,7 +20,7 @@ namespace Cognite.Simulator.Tests
 
     internal static class CdfTestClient
     {
-        internal const long TestDataset = 7900866844615420;
+        internal const long TestDataset = 8148496886298377;
         private static int _configIdx;
         private static string? _statePath;
 

--- a/Cognite.Simulator.Tests/ExtensionsTests/DataPointsTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/DataPointsTest.cs
@@ -57,8 +57,8 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             // that it contains data points in this time range
             CogniteSdk.TimeRange range = new()
             {
-                Min = 1632571875265,
-                Max = 1632615015265
+                Min = 1631294940000,
+                Max = 1631296740000
             };
             
             // Test max aggregation. A single data point should be returned

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -40,7 +40,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
         {
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
-            services.AddHttpClient<FileDownloadClient>();
+            services.AddHttpClient<FileStorageClient>();
             services.AddSingleton<ModeLibraryTest>();
             services.AddSingleton<StagingArea<ModelParsingInfo>>();
             services.AddSingleton<ConfigurationLibraryTest>();
@@ -61,6 +61,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             using var source = new CancellationTokenSource();
             using var provider = services.BuildServiceProvider();
             var cdf = provider.GetRequiredService<Client>();
+            var FileStorageClient = provider.GetRequiredService<FileStorageClient>();
 
             // prepopulate routine in CDF
             SimulatorRoutineRevision revision;
@@ -68,12 +69,14 @@ namespace Cognite.Simulator.Tests.UtilsTests
             if (useConstInputs) {
                 revision = await SeedData.GetOrCreateSimulatorRoutineRevision(
                     cdf,
+                    FileStorageClient,
                     SeedData.SimulatorRoutineCreateWithInputConstants,
                     SeedData.SimulatorRoutineRevisionWithInputConstants
                 ).ConfigureAwait(false);
             } else {
                 revision = await SeedData.GetOrCreateSimulatorRoutineRevision(
                     cdf,
+                    FileStorageClient,
                     SeedData.SimulatorRoutineCreate,
                     SeedData.SimulatorRoutineRevision
                 ).ConfigureAwait(false);

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationSchedulerTest.cs
@@ -25,7 +25,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
         {
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
-            services.AddHttpClient<FileDownloadClient>();
+            services.AddHttpClient<FileStorageClient>();
             services.AddSingleton<ConfigurationLibraryTest>();
             services.AddSingleton(new ConnectorConfig
             {
@@ -44,17 +44,19 @@ namespace Cognite.Simulator.Tests.UtilsTests
             using var source = new CancellationTokenSource();
             using var provider = services.BuildServiceProvider();
             var cdf = provider.GetRequiredService<Client>();
+            var FileStorageClient = provider.GetRequiredService<FileStorageClient>();
+            await TestHelpers.SimulateProsperRunningAsync(cdf, "scheduler-test-connector").ConfigureAwait(false);
 
             /// prepopulate the routine revision
             var revision = await SeedData.GetOrCreateSimulatorRoutineRevision(
                 cdf,
+                FileStorageClient,
                 SeedData.SimulatorRoutineCreateScheduled,
                 SeedData.SimulatorRoutineRevisionCreateScheduled
             ).ConfigureAwait(false);
 
             try
             {
-                await TestHelpers.SimulateProsperRunningAsync(cdf, "scheduler-test-connector").ConfigureAwait(false);
 
                 stateConfig = provider.GetRequiredService<StateStoreConfig>();
                 var configLib = provider.GetRequiredService<ConfigurationLibraryTest>();

--- a/Cognite.Simulator.Utils/FileLibrary.cs
+++ b/Cognite.Simulator.Utils/FileLibrary.cs
@@ -58,7 +58,7 @@ namespace Cognite.Simulator.Utils
         private readonly FileLibraryConfig _config;
         private readonly IList<SimulatorConfig> _simulators;
         private readonly IExtractionStateStore _store;
-        private readonly FileDownloadClient _downloadClient;
+        private readonly FileStorageClient _downloadClient;
 
         // Internal objects
         private readonly BaseExtractionState _libState;
@@ -82,7 +82,7 @@ namespace Cognite.Simulator.Utils
             IList<SimulatorConfig> simulators,
             CogniteDestination cdf,
             ILogger logger,
-            FileDownloadClient downloadClient,
+            FileStorageClient downloadClient,
             IExtractionStateStore store = null)
         {
             _config = config;

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.IO;
 using CogniteSdk.Alpha;
+using Cognite.Extensions;
 
 namespace Cognite.Simulator.Utils
 {
@@ -47,7 +48,7 @@ namespace Cognite.Simulator.Utils
             IList<SimulatorConfig> simulators, 
             CogniteDestination cdf, 
             ILogger logger, 
-            FileDownloadClient downloadClient,
+            FileStorageClient downloadClient,
             StagingArea<V> staging,
             IExtractionStateStore store = null) : 
             base(SimulatorDataType.ModelFile, config, simulators, cdf, logger, downloadClient, store)
@@ -96,7 +97,7 @@ namespace Cognite.Simulator.Utils
                 .OrderByDescending(f => f.Version);
             var otherModelVersionsMap = modelVersionsAll
                 .Where(f => f.ModelName != modelName)
-                .ToDictionary(f => f.FilePath, f => true);
+                .ToDictionarySafe(f => f.FilePath, f => true);
             var latestVersion = currentModelVersions.FirstOrDefault();
             var modelVersionsToDelete = currentModelVersions.Skip(1);
             foreach (var version in modelVersionsToDelete)


### PR DESCRIPTION
- Time series, datapoints, and files are prepopulated by the test itself, same as routines, models, etc
- data sets are not prepopulated (those can't be deleted, so we should rather not create them automatically)
- we run CICD against azude-dev (instead of westeurope-1)
- fixed a potential bug with the unsafe `ToDictionary()` call (maybe that's what caused the model status to be stuck?)
- renamed FileDownloadClient into FileStorageClient as it now supports upload as well

PS: I felt like tests run a bit slower, maybe we want to switch to Bluefield at some point instead (easy)