### PR TITLE
fix : state.FilePath null check missing

### DIFF
--- a/Cognite.Simulator.Utils/StateUtils.cs
+++ b/Cognite.Simulator.Utils/StateUtils.cs
@@ -41,7 +41,7 @@ namespace Cognite.Simulator.Utils
 
             foreach (var state in stateToDelete)
             {
-                if (!filesInUseMap.ContainsKey(state.FilePath))
+                if (state.FilePath != null && !filesInUseMap.ContainsKey(state.FilePath))
                 {
                     DeleteFileAndDirectory(state.FilePath, state.IsInDirectory);
                 }


### PR DESCRIPTION
This line prevented the connector from starting on a new, empty project with no models(files). The ContainsKey was throwing an exception that input to the function is NULL.