### PR TITLE
Fix CD permissions to create releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,12 @@ on:
     branches: [ main ]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# and creating releases.
 permissions:
   actions: read
   pages: write
   id-token: write
+  contents: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.


### PR DESCRIPTION
seems like after the recent changes https://github.com/cognitedata/dotnet-simulator-utils/pull/153/files 
we lost the ability to release