### PR TITLE
tests: use a new ts external id on each run

### DIFF
--- a/Cognite.Simulator.Tests/ExtensionsTests/DataPointsTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/DataPointsTest.cs
@@ -49,13 +49,15 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             var cdf = provider.GetRequiredService<Client>();
             var dataPoints = cdf.DataPoints;
 
+            await SeedData.GetOrCreateTestTimeseries(cdf).ConfigureAwait(false);
+
             // Tests assume the given time series exists in the test project and
             // that it contains data points in this time range
             var samplingConfiguration = new SamplingConfiguration(start: 1631294940000, end: 1631296740000);
             
             // Test max aggregation. A single data point should be returned
             var (timestamps, values) = await dataPoints.GetSample(
-                "SimConnect-IntegrationTests-OnOffValues",
+                "utils-tests-OnOffValues",
                 Extensions.DataPointAggregate.Max,
                 800,
                 samplingConfiguration,
@@ -70,7 +72,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             // No data points in the range. Throw exception
             _ = Assert.ThrowsAsync<DataPointSampleNotFoundException>(
                 async () => await dataPoints.GetSample(
-                  "SimConnect-IntegrationTests-OnOffValues",
+                  "utils-tests-OnOffValues",
                   Extensions.DataPointAggregate.Max,
                   1,
                   range2,
@@ -80,7 +82,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             // No data points in the range, and before the range. Since aggregation
             // is step interpolation should search forward in time for any data points
             var (timestamps2, values2) = await dataPoints.GetSample(
-                "SimConnect-IntegrationTests-OnOffValues",
+                "utils-tests-OnOffValues",
                 Extensions.DataPointAggregate.StepInterpolation,
                 1,
                 range2,
@@ -104,7 +106,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             var currentTimeEpoch = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             var disabledDataSampling = new SamplingConfiguration( end: currentTimeEpoch );
             var (timestamp, value) = await dataPoints.GetLatestValue(
-                "SimConnect-IntegrationTests-OnOffValues",
+                "utils-tests-OnOffValues",
                 disabledDataSampling,
                 System.Threading.CancellationToken.None).ConfigureAwait(false);
             

--- a/Cognite.Simulator.Tests/SeedData.cs
+++ b/Cognite.Simulator.Tests/SeedData.cs
@@ -227,19 +227,16 @@ namespace Cognite.Simulator.Tests
         };
 
         public static async Task<TimeSeries> GetOrCreateTimeSeries(Client sdk, TimeSeriesCreate timeSeries) {
-            var timeSeriesRes = await sdk.TimeSeries.RetrieveAsync(
-                new List<string>() { timeSeries.ExternalId }, true
-            ).ConfigureAwait(false);
-
-            if (timeSeriesRes.Count() > 0)
-            {
+            try {
+                var res = await sdk.TimeSeries.CreateAsync(
+                new List<TimeSeriesCreate> { timeSeries }).ConfigureAwait(false);
+                return res.First();
+            } catch (ResponseException e) when (e.Code == 400) {
+                var timeSeriesRes = await sdk.TimeSeries.RetrieveAsync(
+                    new List<string>() { timeSeries.ExternalId }, true
+                ).ConfigureAwait(false);
                 return timeSeriesRes.First();
             }
-
-            var res = await sdk.TimeSeries.CreateAsync(
-                new List<TimeSeriesCreate> { timeSeries }).ConfigureAwait(false);
-
-            return res.First();
         }
 
         public static async Task<TimeSeries> GetOrCreateTimeSeries(Client sdk, TimeSeriesCreate timeSeries, long[] timestamps, double[] values)

--- a/Cognite.Simulator.Tests/SeedData.cs
+++ b/Cognite.Simulator.Tests/SeedData.cs
@@ -231,7 +231,7 @@ namespace Cognite.Simulator.Tests
                 var res = await sdk.TimeSeries.CreateAsync(
                 new List<TimeSeriesCreate> { timeSeries }).ConfigureAwait(false);
                 return res.First();
-            } catch (ResponseException e) when (e.Code == 400) {
+            } catch (ResponseException e) when (e.Code == 409) {
                 var timeSeriesRes = await sdk.TimeSeries.RetrieveAsync(
                     new List<string>() { timeSeries.ExternalId }, true
                 ).ConfigureAwait(false);

--- a/Cognite.Simulator.Tests/SeedData.cs
+++ b/Cognite.Simulator.Tests/SeedData.cs
@@ -26,6 +26,7 @@ namespace Cognite.Simulator.Tests
         public static string TestScheduledRoutineExternalId = "Test Scheduled Routine " + Now;
         public static string TestRoutineExternalIdWithTs = "Test Routine with Input TS and extended IO " + Now;
         public static string TestRoutineExternalIdWithTsNoDataSampling = "Test Routine with no data sampling " + Now;
+        public static string TestRoutineTsPrefix = "utils-tests-" + Now;
         public static long TestDataSetId = 386820206154952;
 
         public static async Task<CogniteSdk.Alpha.Simulator> GetOrCreateSimulator(Client sdk, SimulatorCreate simulator)
@@ -213,20 +214,19 @@ namespace Cognite.Simulator.Tests
 
         public static TimeSeriesCreate OnOffValuesTimeSeries = new TimeSeriesCreate()
         {
-            ExternalId = "SimConnect-IntegrationTests-OnOffValues",
+            ExternalId = "utils-tests-OnOffValues",
             Name = "On/Off Values",
             DataSetId = TestDataSetId,
         };
 
         public static TimeSeriesCreate SsdSensorDataTimeSeries = new TimeSeriesCreate()
         {
-            ExternalId = "SimConnect-IntegrationTests-SsdSensorData",
+            ExternalId = "utils-tests-SsdSensorData",
             Name = "SSD Sensor Data",
             DataSetId = TestDataSetId,
         };
 
-        public static async Task<TimeSeries> GetOrCreateTimeSeries(Client sdk, TimeSeriesCreate timeSeries, long[] timestamps, double[] values)
-        {
+        public static async Task<TimeSeries> GetOrCreateTimeSeries(Client sdk, TimeSeriesCreate timeSeries) {
             var timeSeriesRes = await sdk.TimeSeries.RetrieveAsync(
                 new List<string>() { timeSeries.ExternalId }, true
             ).ConfigureAwait(false);
@@ -238,6 +238,13 @@ namespace Cognite.Simulator.Tests
 
             var res = await sdk.TimeSeries.CreateAsync(
                 new List<TimeSeriesCreate> { timeSeries }).ConfigureAwait(false);
+
+            return res.First();
+        }
+
+        public static async Task<TimeSeries> GetOrCreateTimeSeries(Client sdk, TimeSeriesCreate timeSeries, long[] timestamps, double[] values)
+        {
+            var res = await GetOrCreateTimeSeries(sdk, timeSeries).ConfigureAwait(false);
 
             var dataPoints = new NumericDatapoints();
 
@@ -259,15 +266,23 @@ namespace Cognite.Simulator.Tests
 
             await sdk.DataPoints.CreateAsync(points).ConfigureAwait(false);
 
-            return res.First();
+            return res;
+        }
+
+        public static async Task<IEnumerable<TimeSeries>> GetOrCreateTestTimeseries(Client sdk)
+        {
+            var testValues = new TestValues();
+            var task1 = GetOrCreateTimeSeries(sdk, OnOffValuesTimeSeries, testValues.TimeLogic, testValues.DataLogic);
+            var task2 = GetOrCreateTimeSeries(sdk, SsdSensorDataTimeSeries, testValues.TimeSsd, testValues.DataSsd);
+            var res = await Task.WhenAll(task1, task2).ConfigureAwait(false);
+            return res.ToList();
         }
 
 
         public static async Task<SimulatorRoutineRevision> GetOrCreateSimulatorRoutineRevision(Client sdk, FileStorageClient fileStorageClient, SimulatorRoutineCreateCommandItem routineToCreate, SimulatorRoutineRevisionCreate revisionToCreate)
         {
             var testValues = new TestValues();
-            await GetOrCreateTimeSeries(sdk, OnOffValuesTimeSeries, testValues.TimeLogic, testValues.DataLogic).ConfigureAwait(false);
-            await GetOrCreateTimeSeries(sdk, SsdSensorDataTimeSeries, testValues.TimeSsd, testValues.DataSsd).ConfigureAwait(false);
+            await GetOrCreateTestTimeseries(sdk).ConfigureAwait(false);
             await GetOrCreateSimulatorModelRevisions(sdk, fileStorageClient).ConfigureAwait(false);
             var routine = await GetOrCreateSimulatorRoutine(sdk, routineToCreate).ConfigureAwait(false);
 
@@ -345,7 +360,7 @@ namespace Cognite.Simulator.Tests
                     new SimulatorRoutineRevisionLogicalCheck
                     {
                         Enabled = true,
-                        TimeseriesExternalId = "SimConnect-IntegrationTests-OnOffValues",
+                        TimeseriesExternalId = "utils-tests-OnOffValues",
                         Aggregate = "stepInterpolation",
                         Operator = "eq",
                         Value = 1
@@ -356,7 +371,7 @@ namespace Cognite.Simulator.Tests
                     new SimulatorRoutineRevisionSteadyStateDetection
                     {
                         Enabled = true,
-                        TimeseriesExternalId = "SimConnect-IntegrationTests-SsdSensorData",
+                        TimeseriesExternalId = "utils-tests-SsdSensorData",
                         Aggregate = "average",
                         MinSectionSize = 60,
                         VarThreshold = 1.0,
@@ -373,7 +388,7 @@ namespace Cognite.Simulator.Tests
                             Name = "STB/MMscf",
                             Quantity = "LiqRate/GasRate",
                         },
-                        SaveTimeseriesExternalId = "SimConnect-IntegrationTests-IC1-SampledSsd",
+                        SaveTimeseriesExternalId = TestRoutineTsPrefix + "-IC1-SampledSsd",
                     },
                     new SimulatorRoutineRevisionInput() {
                         Name = "Input Constant 2",
@@ -384,7 +399,7 @@ namespace Cognite.Simulator.Tests
                             Name = "STB/MMscf",
                             Quantity = "LiqRate/GasRate",
                         },
-                        SaveTimeseriesExternalId = "SimConnect-IntegrationTests-IC2-SampledSsd",
+                        SaveTimeseriesExternalId = TestRoutineTsPrefix + "-IC2-SampledSsd",
                     },
                 },
                 Outputs = new List<SimulatorRoutineRevisionOutput>() {
@@ -396,7 +411,7 @@ namespace Cognite.Simulator.Tests
                             Name = "STB/MMscf",
                             Quantity = "LiqRate/GasRate",
                         },
-                        SaveTimeseriesExternalId = "SimConnect-IntegrationTests-OT1-Output",
+                        SaveTimeseriesExternalId = TestRoutineTsPrefix + "-OT1-Output",
                     },
                 },
             },
@@ -584,7 +599,7 @@ namespace Cognite.Simulator.Tests
                 {
                     new SimulatorRoutineRevisionLogicalCheck {
                         Enabled = true,
-                        TimeseriesExternalId = "SimConnect-IntegrationTests-OnOffValues",
+                        TimeseriesExternalId = "utils-tests-OnOffValues",
                         Aggregate = "stepInterpolation",
                         Operator = "eq",
                         Value = 1,
@@ -595,7 +610,7 @@ namespace Cognite.Simulator.Tests
                     new SimulatorRoutineRevisionSteadyStateDetection 
                     {
                         Enabled = true,
-                        TimeseriesExternalId = "SimConnect-IntegrationTests-SsdSensorData",
+                        TimeseriesExternalId = "utils-tests-SsdSensorData",
                         Aggregate = "average",
                         MinSectionSize = 60,
                         VarThreshold = 1.0,
@@ -611,7 +626,7 @@ namespace Cognite.Simulator.Tests
                             Name = "STB/MMscf",
                             Quantity = "LiqRate/GasRate",
                         },
-                        SaveTimeseriesExternalId = "SimConnect-IntegrationTests-OT1-Output",
+                        SaveTimeseriesExternalId = TestRoutineTsPrefix + "-OT1-Output",
                     },
                     new SimulatorRoutineRevisionOutput() {
                         Name = "Output Test 2",
@@ -628,14 +643,14 @@ namespace Cognite.Simulator.Tests
                             Quantity = "LiqRate/GasRate",
                         },
                         Aggregate = "average",
-                        SaveTimeseriesExternalId = "SimConnect-IntegrationTests-IT1-SampledSsd",
-                        SourceExternalId = "SimConnect-IntegrationTests-SsdSensorData",
+                        SaveTimeseriesExternalId = TestRoutineTsPrefix + "-IT1-SampledSsd",
+                        SourceExternalId = "utils-tests-SsdSensorData",
                     },
                     new SimulatorRoutineRevisionInput() {
                         Name = "Input Test 2",
                         ReferenceId = "IT2",
                         Aggregate = "average",
-                        SourceExternalId = "SimConnect-IntegrationTests-OnOffValues",
+                        SourceExternalId =  "utils-tests-OnOffValues",
                     },
                 },
             },
@@ -732,7 +747,7 @@ namespace Cognite.Simulator.Tests
                     new SimulatorRoutineRevisionInput() {
                         Name = "Input Test 1",
                         ReferenceId = "IT1",
-                        SourceExternalId = "SimConnect-IntegrationTests-SsdSensorData",
+                        SourceExternalId = "utils-tests-SsdSensorData",
                     },
                 },
             },

--- a/Cognite.Simulator.Tests/UtilsTests/CommonUtilsTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/CommonUtilsTest.cs
@@ -33,6 +33,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var cdf = provider.GetRequiredService<Client>();
             var dataPoints = cdf.DataPoints;
 
+            await SeedData.GetOrCreateTestTimeseries(cdf).ConfigureAwait(false);
+
             var config = NewRoutineConfig();
             config.LogicalCheck.First().Enabled = runLogicCheck;
             config.SteadyStateDetection.First().Enabled = runSsdCheck;
@@ -51,8 +53,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
         private static SimulatorRoutineRevisionConfiguration NewRoutineConfig()
         {
-            // Assumes a time series in CDF with the id SimConnect-IntegrationTests-OnOffValues and
-            // one with id SimConnect-IntegrationTests-SsdSensorData.
+            // Assumes a time series in CDF with the id utils-tests-OnOffValues and
+            // one with id utils-tests-SsdSensorData.
             // The time stamps and values for these time series match the ones used in the DataProcessing
             // library tests
             return new()
@@ -69,7 +71,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     new SimulatorRoutineRevisionLogicalCheck
                     {
                         Enabled = true,
-                        TimeseriesExternalId = "SimConnect-IntegrationTests-OnOffValues",
+                        TimeseriesExternalId = "utils-tests-OnOffValues",
                         Aggregate = "stepInterpolation",
                         Operator = "eq",
                         Value = 1.0
@@ -80,7 +82,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     new SimulatorRoutineRevisionSteadyStateDetection
                     {
                         Enabled = true,
-                        TimeseriesExternalId = "SimConnect-IntegrationTests-SsdSensorData",
+                        TimeseriesExternalId = "utils-tests-SsdSensorData",
                         Aggregate = "average",
                         MinSectionSize = 60,
                         VarThreshold = 1.0,

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
@@ -487,7 +487,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     Assert.NotNull(input.ReferenceId);
                     Assert.True(input.IsConstant);
                     Assert.NotNull(input.Name);
-                    Assert.StartsWith("SimConnect-IntegrationTests-IC", input.SaveTimeseriesExternalId);
+                    Assert.StartsWith(SeedData.TestRoutineTsPrefix + "-IC", input.SaveTimeseriesExternalId);
                 }
             }
             finally


### PR DESCRIPTION
this tries to assign new timeseries ids for inputs/outputs every time the test runs. should help with running tests in parallel.

we currently have a lot of error like: `No output time series were created [SimConnect-IntegrationTests-OT1-Output]`