### PR TITLE
fix test simulator cleanup

### DIFF
--- a/Cognite.Simulator.Tests/CdfTestClient.cs
+++ b/Cognite.Simulator.Tests/CdfTestClient.cs
@@ -87,7 +87,7 @@ namespace Cognite.Simulator.Tests
             // Configure CDF Client
             services.AddHttpClient<Client.Builder>()
                 .AddPolicyHandler((provider, message) => {
-                    return CogniteExtensions.GetRetryPolicy(null, 5, 5000);
+                    return CogniteExtensions.GetRetryPolicy(null, 10, 10000);
                 });
             services.AddSingleton(p => {
                 var auth = p.GetRequiredService<IAuthenticator>();

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
@@ -25,7 +25,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
         public async Task TestConnectorBase()
         {
             var timestamp = DateTime.UtcNow.ToUnixTimeMilliseconds();
-            var simulatorName = $"TestSim {timestamp}";
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
             services.AddSingleton<RemoteConfigManager<Utils.BaseConfig>>(provider => null!);
@@ -36,7 +35,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             services.AddSingleton<ScopedRemoteApiSink>();
             var simConfig = new SimulatorConfig
             {
-                Name = simulatorName,
+                Name = SeedData.TestSimulatorExternalId,
                 DataSetId = SeedData.TestDataSetId
             };
             services.AddSingleton(simConfig);
@@ -49,54 +48,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var cdf = provider.GetRequiredService<Client>();
             var cdfConfig = provider.GetRequiredService<CogniteConfig>();
 
-            // prepopulate the TestSim simulator
-            await cdf.Alpha.Simulators.CreateAsync(
-                new []
-                {
-                    new SimulatorCreate()
-                        {
-                            ExternalId = simulatorName,
-                            Name = "TestSim",
-                            FileExtensionTypes = new List<string> { "test" },
-                            ModelTypes = new List<SimulatorModelType> {
-                                new SimulatorModelType {
-                                    Name = "Oil and Water Well",
-                                    Key = "OilWell",
-                                },
-                                new SimulatorModelType {
-                                    Name = "Dry and Wet Gas Well",
-                                    Key = "GasWell",
-                                },
-                                new SimulatorModelType {
-                                    Name = "Retrograde Condensate Well",
-                                    Key = "RetrogradeWell",
-                                },
-                            },
-                            StepFields = new List<SimulatorStepField> {
-                                new SimulatorStepField {
-                                    StepType = "get/set",
-                                    Fields = new List<SimulatorStepFieldParam> {
-                                        new SimulatorStepFieldParam {
-                                            Name = "address",
-                                            Label = "OpenServer Address",
-                                            Info = "Enter the address of the PROSPER variable, i.e. PROSPER.ANL. SYS. Pres",
-                                        },
-                                    },
-                                },
-                                new SimulatorStepField {
-                                    StepType = "command",
-                                    Fields = new List<SimulatorStepFieldParam> {
-                                        new SimulatorStepFieldParam {
-                                            Name = "command",
-                                            Label = "OpenServer Command",
-                                            Info = "Enter the command to send to the PROSPER, i.e. Simulate",
-                                        },
-                                    },
-                                },
-                            },
-                        }
-                }
-            ).ConfigureAwait(false);
+            await SeedData.GetOrCreateSimulator(cdf, SeedData.SimulatorCreate).ConfigureAwait(false);
 
             try
             {
@@ -107,10 +59,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 var integrationsRes = await cdf.Alpha.Simulators.ListSimulatorIntegrationsAsync(
                     new SimulatorIntegrationQuery(),
                     source.Token).ConfigureAwait(false);
-                var integration = integrationsRes.Items.FirstOrDefault(i => i.SimulatorExternalId == simulatorName);
+                var integration = integrationsRes.Items.FirstOrDefault(i => i.SimulatorExternalId == SeedData.TestSimulatorExternalId);
 
                 Assert.NotNull(integration);
-                Assert.Equal(simulatorName, integration.SimulatorExternalId);
+                Assert.Equal(SeedData.TestSimulatorExternalId, integration.SimulatorExternalId);
                 Assert.Equal("1.2.3", integration.SimulatorVersion);
                 Assert.Equal(SeedData.TestDataSetId, integration.DataSetId);
                 Assert.Equal("v0.0.1", integration.ConnectorVersion);
@@ -134,7 +86,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             finally
             {
                 await cdf.Alpha.Simulators.DeleteAsync(
-                    new [] { new Identity(simulatorName) },
+                    new [] { new Identity(SeedData.TestSimulatorExternalId) },
                     source.Token).ConfigureAwait(false);
                 await cdf.ExtPipes
                     .DeleteAsync(new []{ cdfConfig.ExtractionPipeline?.PipelineId }, CancellationToken.None).ConfigureAwait(false); 

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
@@ -85,9 +85,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
             finally
             {
-                await cdf.Alpha.Simulators.DeleteAsync(
-                    new [] { new Identity(SeedData.TestSimulatorExternalId) },
-                    source.Token).ConfigureAwait(false);
+                await SeedData.DeleteSimulator(cdf, SeedData.TestSimulatorExternalId).ConfigureAwait(false);
                 await cdf.ExtPipes
                     .DeleteAsync(new []{ cdfConfig.ExtractionPipeline?.PipelineId }, CancellationToken.None).ConfigureAwait(false); 
             }


### PR DESCRIPTION
simplify a test so it uses a seed data instead of creating the simulator resource in line.
also change the test cleanup logic, so we reuse `SeedData.DeleteSimulator` which also removes legacy simulator objects when those are found in the project