### PR TITLE
add missing cancellation tokens

### DIFF
--- a/Cognite.Simulator.Tests/IntegrationTests/ConnectorRuntimeTest.cs
+++ b/Cognite.Simulator.Tests/IntegrationTests/ConnectorRuntimeTest.cs
@@ -175,7 +175,8 @@ connector:
             public Task<Dictionary<string, SimulatorValueItem>> RunSimulation(
                 SampleModelFilestate modelState,
                 SimulatorRoutineRevision routineRevision,
-                Dictionary<string, SimulatorValueItem> inputData
+                Dictionary<string, SimulatorValueItem> inputData,
+                CancellationToken token
             )
             {
                 _logger.LogInformation("CalculatorClient Running a simulation");
@@ -183,7 +184,7 @@ connector:
                 {
                     Dictionary<string, SimulatorValueItem> result = new Dictionary<string, SimulatorValueItem>();
                     var routine = new CalculatorRoutineAutomation(routineRevision, inputData, _logger);
-                    result = routine.PerformSimulation();
+                    result = routine.PerformSimulation(token);
                     return Task.FromResult(result);
                 }
                 finally
@@ -225,7 +226,7 @@ connector:
                 return resultItem;
             }
 
-            public override void RunCommand(Dictionary<string, string> arguments)
+            public override void RunCommand(Dictionary<string, string> arguments, CancellationToken token)
             {
             }
 

--- a/Cognite.Simulator.Tests/IntegrationTests/ConnectorRuntimeTest.cs
+++ b/Cognite.Simulator.Tests/IntegrationTests/ConnectorRuntimeTest.cs
@@ -162,12 +162,12 @@ connector:
                 return Task.CompletedTask;
             }
 
-            public string GetConnectorVersion()
+            public string GetConnectorVersion(CancellationToken _token)
             {
                 return CommonUtils.GetAssemblyVersion();
             }
 
-            public string GetSimulatorVersion()
+            public string GetSimulatorVersion(CancellationToken _token) 
             {
                 return "2.0.1";
             }

--- a/Cognite.Simulator.Tests/IntegrationTests/ConnectorRuntimeTest.cs
+++ b/Cognite.Simulator.Tests/IntegrationTests/ConnectorRuntimeTest.cs
@@ -210,7 +210,7 @@ connector:
             {
             }
 
-            public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments)
+            public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments, CancellationToken token)
             {
                 var resultItem = new SimulatorValueItem()
                     {
@@ -230,7 +230,7 @@ connector:
             {
             }
 
-            public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments)
+            public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments, CancellationToken token)
             {
             }
         }

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
@@ -123,12 +123,12 @@ namespace Cognite.Simulator.Tests.UtilsTests
             _pipeline = pipeline;
         }
 
-        public override string GetConnectorVersion()
+        public override string GetConnectorVersion(CancellationToken _token)
         {
             return "v0.0.1";
         }
 
-        public override string GetSimulatorVersion(string simulator)
+        public override string GetSimulatorVersion(string simulator, CancellationToken _token)
         {
             return "1.2.3";
         }

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
@@ -122,7 +122,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             {
             }
 
-            public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments)
+            public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments, CancellationToken token)
             {
                 throw new NotImplementedException();
             }
@@ -131,7 +131,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             {
             }
 
-            public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments)
+            public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments, CancellationToken token)
             {
             }
         }

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
@@ -98,7 +98,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
             public Task<Dictionary<string, SimulatorValueItem>> RunSimulation(
                 DefaultModelFilestate modelState,
                 SimulatorRoutineRevision routineRevision,
-                Dictionary<string, SimulatorValueItem> inputData
+                Dictionary<string, SimulatorValueItem> inputData,
+                CancellationToken token
             )
             {
                 throw new NotImplementedException();
@@ -126,7 +127,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 throw new NotImplementedException();
             }
 
-            public override void RunCommand(Dictionary<string, string> arguments)
+            public override void RunCommand(Dictionary<string, string> arguments, CancellationToken token)
             {
             }
 

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
@@ -85,12 +85,12 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 throw new NotImplementedException();
             }
 
-            public string GetConnectorVersion()
+            public string GetConnectorVersion(CancellationToken _token)
             {
                 return CommonUtils.GetAssemblyVersion();
             }
 
-            public string GetSimulatorVersion()
+            public string GetSimulatorVersion(CancellationToken _token)
             {
                 return "2.0.1";
             }

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -456,12 +456,12 @@ namespace Cognite.Simulator.Tests.UtilsTests
             throw new NotImplementedException();
         }
 
-        public string GetConnectorVersion()
+        public string GetConnectorVersion(CancellationToken _token)
         {
             throw new NotImplementedException();
         }
 
-        public string GetSimulatorVersion()
+        public string GetSimulatorVersion(CancellationToken _token)
         {
             throw new NotImplementedException();
         }

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -394,7 +394,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             };
         }
 
-        public override void RunCommand(Dictionary<string, string> arguments)
+        public override void RunCommand(Dictionary<string, string> arguments, CancellationToken token)
         {
             if (arguments == null)
             {
@@ -469,11 +469,12 @@ namespace Cognite.Simulator.Tests.UtilsTests
         public Task<Dictionary<string, SimulatorValueItem>> RunSimulation(
             TestFileState modelState, 
             SimulatorRoutineRevision simulationConfiguration, 
-            Dictionary<string, SimulatorValueItem> inputData)
+            Dictionary<string, SimulatorValueItem> inputData,
+            CancellationToken token)
         {
             var routine = new SampleRoutine(simulationConfiguration, inputData, _logger);
             _logger.LogWarning("Running a sample routine, not a real simulation");
-            return Task.FromResult(routine.PerformSimulation());
+            return Task.FromResult(routine.PerformSimulation(token));
         }
 
         public Task TestConnection(CancellationToken token)

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -363,7 +363,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             _logger = logger;
         }
         
-        public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments)
+        public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments, CancellationToken token)
         {
             SimulatorValue outputValue;
             if (outputConfig == null)
@@ -410,7 +410,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
         }
 
-        public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments)
+        public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments, CancellationToken token)
         {
             double value;
             if (input == null)

--- a/Cognite.Simulator.Utils/ConnectorBase.cs
+++ b/Cognite.Simulator.Utils/ConnectorBase.cs
@@ -129,7 +129,7 @@ namespace Cognite.Simulator.Utils
         /// Returns the connector version. This is reported periodically to CDF
         /// </summary>
         /// <returns>Connector version</returns>
-        public abstract string GetConnectorVersion();
+        public abstract string GetConnectorVersion(CancellationToken token);
 
         /// <summary>
         /// Returns the version of the given simulator. The connector reads the version and
@@ -137,7 +137,7 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         /// <param name="simulator">Name of the simulator</param>
         /// <returns>Version</returns>
-        public abstract string GetSimulatorVersion(string simulator);
+        public abstract string GetSimulatorVersion(string simulator, CancellationToken token);
 
         /// <summary>
         /// Returns the connector name.This is reported periodically to CDF
@@ -203,8 +203,8 @@ namespace Cognite.Simulator.Utils
                         ExternalId = connectorName,
                         SimulatorExternalId = simulatorExternalId,
                         DataSetId = _config.DataSetId,
-                        ConnectorVersion = GetConnectorVersion() ?? "N/A",
-                        SimulatorVersion = GetSimulatorVersion(simulatorExternalId) ?? "N/A",
+                        ConnectorVersion = GetConnectorVersion(token) ?? "N/A",
+                        SimulatorVersion = GetSimulatorVersion(simulatorExternalId, token) ?? "N/A",
                     };
 
                     var res = await simulatorsApi.CreateSimulatorIntegrationAsync(new List<SimulatorIntegrationCreate> {
@@ -244,8 +244,8 @@ namespace Cognite.Simulator.Utils
                 var integrationUpdate = init ? new SimulatorIntegrationUpdate
                 {
                     DataSetId = new Update<long> { Set = _config.DataSetId },
-                    ConnectorVersion = new Update<string> { Set = GetConnectorVersion() ?? "N/A" },
-                    SimulatorVersion = new Update<string> { Set = GetSimulatorVersion(simulatorExternalId) ?? "N/A" },
+                    ConnectorVersion = new Update<string> { Set = GetConnectorVersion(token) ?? "N/A" },
+                    SimulatorVersion = new Update<string> { Set = GetSimulatorVersion(simulatorExternalId, token) ?? "N/A" },
                     ConnectorStatus = new Update<string> { Set = ConnectorStatus.IDLE.ToString() },
                     ConnectorStatusUpdatedTime = new Update<long> { Set = DateTime.UtcNow.ToUnixTimeMilliseconds() },
                     Heartbeat = new Update<long> { Set = DateTime.UtcNow.ToUnixTimeMilliseconds() },

--- a/Cognite.Simulator.Utils/DefaultClasses/DefaultConnector.cs
+++ b/Cognite.Simulator.Utils/DefaultClasses/DefaultConnector.cs
@@ -61,14 +61,14 @@ namespace Cognite.Simulator.Utils
                     "0.0.1");
         }
 
-        public override string GetConnectorVersion()
+        public override string GetConnectorVersion(CancellationToken token)
         {
-            return _simulatorClient.GetConnectorVersion();
+            return _simulatorClient.GetConnectorVersion(token);
         }
 
-        public override string GetSimulatorVersion(string simulator)
+        public override string GetSimulatorVersion(string simulator, CancellationToken token)
         {
-            return _simulatorClient.GetSimulatorVersion();
+            return _simulatorClient.GetSimulatorVersion(token);
         }
 
         public override async Task Init(CancellationToken token)

--- a/Cognite.Simulator.Utils/RoutineImplementationBase.cs
+++ b/Cognite.Simulator.Utils/RoutineImplementationBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Cognite.Simulator.Utils
@@ -71,15 +72,18 @@ namespace Cognite.Simulator.Utils
         /// Invoke the given command on the simulator using the provided arguments.
         /// </summary>
         /// <param name="arguments">Arguments</param>
-        public abstract void RunCommand(Dictionary<string, string> arguments);
+        /// <param name="token">Cancellation token</param>
+        public abstract void RunCommand(Dictionary<string, string> arguments, CancellationToken token);
 
         /// <summary>
         /// Perform the simulation routine and collect the results
         /// </summary>
+        /// <param name="token">Cancellation token</param>
         /// <returns>Simulation results</returns>
         /// <exception cref="SimulationException">When the simulation configuration is invalid</exception>
         /// <exception cref="SimulationRoutineException">When the routine execution fails</exception>
-        public virtual Dictionary<string, SimulatorValueItem> PerformSimulation()
+        /// <exception cref="OperationCanceledException">When the cancellation token is cancelled</exception>
+        public virtual Dictionary<string, SimulatorValueItem> PerformSimulation(CancellationToken token)
         {
             _simulationResults.Clear();
             if (_script == null || !_script.Any())
@@ -93,7 +97,7 @@ namespace Cognite.Simulator.Utils
             {
                 try
                 {
-                    ParseScriptStage(stage);
+                    ParseScriptStage(stage, token);
                 }
                 catch (SimulationRoutineException e)
                 {
@@ -104,7 +108,7 @@ namespace Cognite.Simulator.Utils
             return _simulationResults;
         }
 
-        private void ParseScriptStage(SimulatorRoutineRevisionScriptStage stage)
+        private void ParseScriptStage(SimulatorRoutineRevisionScriptStage stage, CancellationToken token)
         {
             var orderedSteps = stage.Steps.OrderBy(s => s.Order).ToList();
             foreach (var step in orderedSteps)
@@ -115,17 +119,17 @@ namespace Cognite.Simulator.Utils
                     {
                         case "Command":
                             {
-                                ParseCommand(step.Arguments);
+                                ParseCommand(step.Arguments, token);
                                 break;
                             }
                         case "Set":
                             {
-                                ParseSet(step.Arguments);
+                                ParseSet(step.Arguments, token);
                                 break;
                             }
                         case "Get":
                             {
-                                ParseGet(step.Arguments);
+                                ParseGet(step.Arguments, token);
                                 break;
                             }
                             throw new SimulationRoutineException($"Invalid stage step: {step.StepType}", stepNumber: step.Order);
@@ -142,14 +146,14 @@ namespace Cognite.Simulator.Utils
             }
         }
 
-        private void ParseCommand(Dictionary<string, string> arguments)
+        private void ParseCommand(Dictionary<string, string> arguments, CancellationToken token)
         {
             _logger.LogDebug("Running command: {Command}", SimulatorLoggingUtils.FlattenDictionary(arguments));
             // Perform command
-            RunCommand(arguments);
+            RunCommand(arguments, token);
         }
 
-        private void ParseGet(Dictionary<string, string> arguments)
+        private void ParseGet(Dictionary<string, string> arguments, CancellationToken token)
         {
             if (!arguments.TryGetValue("referenceId", out string argRefId))
             {
@@ -172,7 +176,7 @@ namespace Cognite.Simulator.Utils
             }
         }
 
-        private void ParseSet(Dictionary<string, string> arguments)
+        private void ParseSet(Dictionary<string, string> arguments, CancellationToken token)
         {
             if (!arguments.TryGetValue("referenceId", out string argRefId))
             {

--- a/Cognite.Simulator.Utils/RoutineImplementationBase.cs
+++ b/Cognite.Simulator.Utils/RoutineImplementationBase.cs
@@ -52,10 +52,12 @@ namespace Cognite.Simulator.Utils
         /// <param name="inputConfig">Input configuration</param>
         /// <param name="input">Input value</param>
         /// <param name="arguments">Extra arguments</param>
+        /// <param name="token">Cancellation token</param>
         public abstract void SetInput(
             SimulatorRoutineRevisionInput inputConfig,
             SimulatorValueItem input,
-            Dictionary<string, string> arguments);
+            Dictionary<string, string> arguments,
+            CancellationToken token);
 
         /// <summary>
         /// Gets a numeric simulation result that should be saved
@@ -63,10 +65,12 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         /// <param name="outputConfig">Output time series configuration</param>
         /// <param name="arguments">Extra arguments</param>
+        /// <param name="token">Cancellation token</param>
         /// <returns></returns>
         public abstract SimulatorValueItem GetOutput(
             SimulatorRoutineRevisionOutput outputConfig,
-            Dictionary<string, string> arguments);
+            Dictionary<string, string> arguments,
+            CancellationToken token);
 
         /// <summary>
         /// Invoke the given command on the simulator using the provided arguments.
@@ -168,7 +172,7 @@ namespace Cognite.Simulator.Utils
                     var output = matchingOutputs.First();
                     string flattenedArguments = SimulatorLoggingUtils.FlattenDictionary(extraArgs);
                     _logger.LogDebug("Getting output for Reference Id: {Output}. Arguments: {Arguments}", output.ReferenceId, flattenedArguments);
-                    _simulationResults[output.ReferenceId] = GetOutput(output, extraArgs);
+                    _simulationResults[output.ReferenceId] = GetOutput(output, extraArgs, token);
                 }
             else
             {
@@ -190,7 +194,7 @@ namespace Cognite.Simulator.Utils
             {
                 string flattenedArguments = SimulatorLoggingUtils.FlattenDictionary(extraArgs);
                 _logger.LogDebug("Setting input for Reference Id: {Input}. Arguments: {Arguments}", matchingInputs.First().ReferenceId, flattenedArguments);
-                SetInput(matchingInputs.First(), _inputData[argRefId], extraArgs);
+                SetInput(matchingInputs.First(), _inputData[argRefId], extraArgs, token);
             }
             else
             {

--- a/Cognite.Simulator.Utils/RoutineRunnerBase.cs
+++ b/Cognite.Simulator.Utils/RoutineRunnerBase.cs
@@ -301,9 +301,9 @@ namespace Cognite.Simulator.Utils
 
         Task ExtractModelInformation(T state, CancellationToken _token);
 
-        string GetSimulatorVersion();
+        string GetSimulatorVersion(CancellationToken _token);
 
-        string GetConnectorVersion();
+        string GetConnectorVersion(CancellationToken _token);
 
         /// <summary>
         /// Tests the connection to the simulator.

--- a/Cognite.Simulator.Utils/RoutineRunnerBase.cs
+++ b/Cognite.Simulator.Utils/RoutineRunnerBase.cs
@@ -200,7 +200,7 @@ namespace Cognite.Simulator.Utils
                 }
             }
             var results = await SimulatorClient
-                .RunSimulation(modelState, routineRevision, inputData)
+                .RunSimulation(modelState, routineRevision, inputData, token)
                 .ConfigureAwait(false);
 
             _logger.LogDebug("Saving simulation results as time series");
@@ -293,11 +293,12 @@ namespace Cognite.Simulator.Utils
         /// <param name="modelState">Model state object</param>
         /// <param name="simulationConfiguration">Simulation configuration object</param>
         /// <param name="inputData">Input data</param>
+        /// <param name="token">Cancellation token</param>
         /// <returns></returns>
         Task<Dictionary<string, SimulatorValueItem>> RunSimulation(
             T modelState, 
             V simulationConfiguration, 
-            Dictionary<string, SimulatorValueItem> inputData);
+            Dictionary<string, SimulatorValueItem> inputData, CancellationToken token);
 
         Task ExtractModelInformation(T state, CancellationToken _token);
 

--- a/Sample.Calculator.Simulator/Simulator.cs
+++ b/Sample.Calculator.Simulator/Simulator.cs
@@ -69,7 +69,7 @@ internal class CalculatorRoutine : RoutineImplementationBase
     {
     }
 
-    public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments)
+    public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments, CancellationToken token)
     {
         Console.WriteLine("Handling outputs");
         var resultItem = new SimulatorValueItem() {
@@ -90,7 +90,7 @@ internal class CalculatorRoutine : RoutineImplementationBase
         Console.WriteLine("Handling run command");
     }
 
-    public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments)
+    public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments, CancellationToken token)
     {
         Console.WriteLine("Handling inputs");
     }

--- a/Sample.Calculator.Simulator/Simulator.cs
+++ b/Sample.Calculator.Simulator/Simulator.cs
@@ -35,14 +35,15 @@ public class CalculatorSimulatorClient :
     public Task<Dictionary<string, SimulatorValueItem>> RunSimulation(
         CalculatorModelFilestate modelState, 
         SimulatorRoutineRevision routineRevision, 
-        Dictionary<string, SimulatorValueItem> inputData
+        Dictionary<string, SimulatorValueItem> inputData,
+        CancellationToken token
     ) {
         _logger.LogInformation("CalculatorClient Running a simulation");
         try
         {
             Dictionary<string, SimulatorValueItem> result = new Dictionary<string, SimulatorValueItem>();
             var routine = new CalculatorRoutine(routineRevision, inputData, _logger);
-            result = routine.PerformSimulation();
+            result = routine.PerformSimulation(token);
             foreach (var kvp in result)
             {
                 Console.WriteLine($"Key: {kvp.Key}, Value: {kvp.Value}");
@@ -84,7 +85,7 @@ internal class CalculatorRoutine : RoutineImplementationBase
         return resultItem;
     }
 
-    public override void RunCommand(Dictionary<string, string> arguments)
+    public override void RunCommand(Dictionary<string, string> arguments, CancellationToken token)
     {
         Console.WriteLine("Handling run command");
     }

--- a/Sample.Calculator.Simulator/Simulator.cs
+++ b/Sample.Calculator.Simulator/Simulator.cs
@@ -22,12 +22,12 @@ public class CalculatorSimulatorClient :
         return Task.CompletedTask;
     }
 
-    public string GetConnectorVersion()
+    public string GetConnectorVersion(CancellationToken token)
     {
         return CommonUtils.GetAssemblyVersion();
     }
 
-    public string GetSimulatorVersion()
+    public string GetSimulatorVersion(CancellationToken token)
     {
         return "2.0.1";
     }

--- a/Sample.Calculator.Simulator/SimulatorAutomation.cs
+++ b/Sample.Calculator.Simulator/SimulatorAutomation.cs
@@ -99,7 +99,8 @@ public class CalculatorSimulatorAutomationClient :
     public Task<Dictionary<string, SimulatorValueItem>> RunSimulation(
         CalculatorModelFilestate modelState,
         SimulatorRoutineRevision routineRevision,
-        Dictionary<string, SimulatorValueItem> inputData
+        Dictionary<string, SimulatorValueItem> inputData,
+        CancellationToken token
     )
     {
         if (modelState == null) {
@@ -110,7 +111,7 @@ public class CalculatorSimulatorAutomationClient :
         try
         {
             var routine = new CalculatorRoutine(routineRevision, inputData, _logger);
-            var result = routine.PerformSimulation();
+            var result = routine.PerformSimulation(token);
             return Task.FromResult(result);
         }
         finally
@@ -152,7 +153,7 @@ internal class CalculatorRoutineAutomation : RoutineImplementationBase
         return resultItem;
     }
 
-    public override void RunCommand(Dictionary<string, string> arguments)
+    public override void RunCommand(Dictionary<string, string> arguments, CancellationToken token)
     {
         Console.WriteLine("Handling run command");
     }

--- a/Sample.Calculator.Simulator/SimulatorAutomation.cs
+++ b/Sample.Calculator.Simulator/SimulatorAutomation.cs
@@ -137,7 +137,7 @@ internal class CalculatorRoutineAutomation : RoutineImplementationBase
     {
     }
 
-    public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments)
+    public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments, CancellationToken token)
     {
         var resultItem = new SimulatorValueItem()
         {
@@ -158,7 +158,7 @@ internal class CalculatorRoutineAutomation : RoutineImplementationBase
         Console.WriteLine("Handling run command");
     }
 
-    public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments)
+    public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input, Dictionary<string, string> arguments, CancellationToken token)
     {
         Console.WriteLine("Handling inputs");
     }

--- a/Sample.Calculator.Simulator/SimulatorAutomation.cs
+++ b/Sample.Calculator.Simulator/SimulatorAutomation.cs
@@ -86,12 +86,12 @@ public class CalculatorSimulatorAutomationClient :
         state.ParsingInfo.SetSuccess();
     }
 
-    public string GetConnectorVersion()
+    public string GetConnectorVersion(CancellationToken token)
     {
         return CommonUtils.GetAssemblyVersion();
     }
 
-    public string GetSimulatorVersion()
+    public string GetSimulatorVersion(CancellationToken token)
     {
         return "2.0.1";
     }


### PR DESCRIPTION
With retries coming in into our connectors (starting with PROSPER), it is now very important that we pass down the CancellationToken to the connector implementations. This PR adds CancellationTokens to the parts of our code that were missing it.