### PR TITLE
chore: rename build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
   
   build:
     needs: build-matrix
-    runs-on: ubuntu-latest  # Can be any runner, just for reporting
+    runs-on: ubuntu-latest 
     steps:
       - name: Report build status
         run: echo "All matrix builds completed successfully"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  build-matrix:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -36,6 +36,13 @@ jobs:
           name: coverage-${{ matrix.os }}
           path: ./Cognite.Simulator.Tests/TestResults/coverage.opencover.xml
           retention-days: 1
+  
+  build:
+    needs: build-matrix
+    runs-on: ubuntu-latest  # Can be any runner, just for reporting
+    steps:
+      - name: Report build status
+        run: echo "All matrix builds completed successfully"
 
   upload-coverage:
     needs: build

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and Test
 
 on:
   push:


### PR DESCRIPTION
We modified the build action in this PR to use matrix: https://github.com/cognitedata/dotnet-simulator-utils/pull/239 . That caused the Github build status not to be reported correctly; since we are now reporting `build (ubuntu-latest)` and `build(windows-latest)` instead of just one `build`. This PR fixes that so now we are reporting just one `build` status.