### PR TITLE
chore: introduce pre-commit formatting of files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,8 @@ tab_width = 4
 
 # this. and Me. preferences
 dotnet_style_qualification_for_method = true
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = true
 
 #### Diagnostic configuration ####
 

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -22,6 +22,8 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --no-restore
+      - name: Format
+        run: dotnet format --verify-no-changes --severity=error
       - name: Test
         run: dotnet test --no-restore --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/ ./Cognite.Simulator.Tests/ --logger:"console"
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: dotnet-format
+        name: dotnet-format
+        language: system 
+        entry: dotnet format --include 
+        types_or: ["c#"]

--- a/Cognite.DataProcessing/DataSampling.cs
+++ b/Cognite.DataProcessing/DataSampling.cs
@@ -152,7 +152,7 @@ namespace Cognite.DataProcessing
 
             return new TimeSeriesData(time: x, data: yRes, granularity: ts.Granularity, isStep: ts.IsStep);
         }
-        
+
         /// <summary>
         /// Supported logical operations
         /// </summary>

--- a/Cognite.DataProcessing/Detectors.cs
+++ b/Cognite.DataProcessing/Detectors.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using MathNet.Numerics;
 using MathNet.Numerics.Statistics;
 

--- a/Cognite.Simulator.Extensions/DataModel.cs
+++ b/Cognite.Simulator.Extensions/DataModel.cs
@@ -11,7 +11,7 @@ namespace Cognite.Simulator.Extensions
         /// Data type metadata key
         /// </summary>
         public const string DataTypeKey = "dataType";
-        
+
         /// <summary>
         /// Simulator metadata key
         /// </summary>

--- a/Cognite.Simulator.Extensions/DataPointsExtensions.cs
+++ b/Cognite.Simulator.Extensions/DataPointsExtensions.cs
@@ -1,11 +1,13 @@
-﻿using CogniteSdk;
-using CogniteSdk.Resources;
-using Com.Cognite.V1.Timeseries.Proto;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using CogniteSdk;
+using CogniteSdk.Resources;
+
+using Com.Cognite.V1.Timeseries.Proto;
 
 namespace Cognite.Simulator.Extensions
 {
@@ -164,7 +166,7 @@ namespace Cognite.Simulator.Extensions
                         values.Select(dp => dp.Timestamp).ToArray(),
                         values.Select(dp => dp.Average).ToArray());
                 case DataPointAggregate.Max:
-                    return(
+                    return (
                         values.Select(dp => dp.Timestamp).ToArray(),
                         values.Select(dp => dp.Max).ToArray());
                 case DataPointAggregate.Min:
@@ -172,7 +174,7 @@ namespace Cognite.Simulator.Extensions
                         values.Select(dp => dp.Timestamp).ToArray(),
                         values.Select(dp => dp.Min).ToArray());
                 case DataPointAggregate.Count:
-                    return(
+                    return (
                         values.Select(dp => dp.Timestamp).ToArray(),
                         values.Select(dp => dp.Count).ToArray());
                 case DataPointAggregate.Sum:
@@ -300,47 +302,47 @@ namespace Cognite.Simulator.Extensions
         /// Average
         /// </summary>
         Average,
-        
+
         /// <summary>
         /// Maximum
         /// </summary>
         Max,
-        
+
         /// <summary>
         /// Minimum
         /// </summary>
         Min,
-        
+
         /// <summary>
         /// Count
         /// </summary>
         Count,
-        
+
         /// <summary>
         /// Sum
         /// </summary>
         Sum,
-        
+
         /// <summary>
         /// Continuous interpolation
         /// </summary>
         Interpolation,
-        
+
         /// <summary>
         /// Stepwise interpolation
         /// </summary>
         StepInterpolation,
-        
+
         /// <summary>
         /// Total variance
         /// </summary>
         TotalVariation,
-        
+
         /// <summary>
         /// Continuous variance
         /// </summary>
         ContinuousVariance,
-        
+
         /// <summary>
         /// Discrete variance
         /// </summary>

--- a/Cognite.Simulator.Extensions/ExtensionsUtils.cs
+++ b/Cognite.Simulator.Extensions/ExtensionsUtils.cs
@@ -1,8 +1,9 @@
-﻿using Cognite.Extensions;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+
+using Cognite.Extensions;
 
 namespace Cognite.Simulator.Extensions
 {
@@ -86,12 +87,12 @@ namespace Cognite.Simulator.Extensions
         /// Time associated with the simulation, in milliseconds 
         /// </summary>
         public long SimulationTime { get; }
-        
+
         /// <summary>
         /// Start of the sampling range, in milliseconds
         /// </summary>
         public long? Start { get; }
-        
+
         /// <summary>
         /// End of the sampling range, in milliseconds
         /// </summary>
@@ -120,13 +121,14 @@ namespace Cognite.Simulator.Extensions
                     SimulationTime = End;
                 else
                     throw new ArgumentException("Invalid sampling position");
-            } else
+            }
+            else
             {
                 SimulationTime = end;
             }
         }
     }
-    
+
     /// <summary>
     /// Defines the position of the simulation time relative to the sampling window
     /// </summary>

--- a/Cognite.Simulator.Extensions/SimulatorsExtensions.cs
+++ b/Cognite.Simulator.Extensions/SimulatorsExtensions.cs
@@ -1,22 +1,26 @@
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using CogniteSdk.Alpha;
-using Cognite.Extractor.Common;
-using CogniteSdk;
-using CogniteSdk.Resources.Alpha;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Cognite.Extensions;
+using Cognite.Extractor.Common;
+
+using CogniteSdk;
+using CogniteSdk.Alpha;
+using CogniteSdk.Resources.Alpha;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cognite.Simulator.Extensions
 {
     /// <summary>
     /// Class containing extensions to the CDF Simulators resource with utility methods
     /// </summary>
-    public static class SimulatorsExtensions {
+    public static class SimulatorsExtensions
+    {
         private static ILogger _logger = new NullLogger<Client>();
 
         /// <summary>
@@ -47,7 +51,8 @@ namespace Cognite.Simulator.Extensions
             _logger.LogDebug("Updating logs. Number of log entries: {Number}. Number of chunks: {Chunks}", items.Count, logsByChunks.Count);
             var generators = logsByChunks
                 .Select<IEnumerable<SimulatorLogDataEntry>, Func<Task>>(
-                (chunk, idx) => async () => {
+                (chunk, idx) => async () =>
+                {
 
                     var item = new SimulatorLogUpdateItem(id)
                     {
@@ -64,7 +69,8 @@ namespace Cognite.Simulator.Extensions
             int taskNum = 0;
             await generators.RunThrottled(
                 1,
-                (_) => {
+                (_) =>
+                {
                     if (logsByChunks.Count > 1)
                         _logger.LogDebug("{MethodName} completed {NumDone}/{TotalNum} tasks",
                             nameof(UpdateLogsBatch), ++taskNum, logsByChunks.Count);
@@ -72,7 +78,7 @@ namespace Cognite.Simulator.Extensions
                 CancellationToken.None
             ).ConfigureAwait(false);
         }
-    
+
         /// <summary>
         /// Updates the simulation model revision status and status message in CDF.
         /// </summary>
@@ -91,9 +97,11 @@ namespace Cognite.Simulator.Extensions
         )
         {
             var modelRevisionPatch =
-                new SimulatorModelRevisionUpdateItem(id) {
+                new SimulatorModelRevisionUpdateItem(id)
+                {
                     Update =
-                        new SimulatorModelRevisionUpdate {
+                        new SimulatorModelRevisionUpdate
+                        {
                             Status = new Update<SimulatorModelRevisionStatus>(status),
                         }
                 };

--- a/Cognite.Simulator.Extensions/TimeSeriesExtensions.cs
+++ b/Cognite.Simulator.Extensions/TimeSeriesExtensions.cs
@@ -1,13 +1,15 @@
-﻿using CogniteSdk.Resources;
-using Cognite.Extensions;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using System.Threading;
 using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Cognite.Extensions;
+
 using CogniteSdk;
 using CogniteSdk.Alpha;
+using CogniteSdk.Resources;
 
 namespace Cognite.Simulator.Extensions
 {

--- a/Cognite.Simulator.Extensions/Types.cs
+++ b/Cognite.Simulator.Extensions/Types.cs
@@ -44,7 +44,8 @@ namespace Cognite.Simulator.Extensions
         /// </summary>
         public string ExternalIdSafeChars
         {
-            get {
+            get
+            {
                 return ExternalId.ReplaceSlashAndBackslash("_");
             }
         }
@@ -64,8 +65,10 @@ namespace Cognite.Simulator.Extensions
         /// <summary>
         /// Indicates if the time series should be saved back to CDF
         /// </summary>
-        public bool ShouldSaveToTimeSeries {
-            get {
+        public bool ShouldSaveToTimeSeries
+        {
+            get
+            {
                 return !string.IsNullOrEmpty(SaveTimeseriesExternalId);
             }
         }
@@ -76,7 +79,7 @@ namespace Cognite.Simulator.Extensions
     /// </summary>
     public class SimulationOutput : SimulationTimeSeries
     {
-        internal override string TimeSeriesName => 
+        internal override string TimeSeriesName =>
             $"{Name} - OUTPUT - {ReferenceId} - {RoutineRevisionInfo.ExternalIdSafeChars}";
 
         internal override string TimeSeriesDescription =>

--- a/Cognite.Simulator.Tests/CdfTestClient.cs
+++ b/Cognite.Simulator.Tests/CdfTestClient.cs
@@ -1,13 +1,17 @@
-﻿using Cognite.Extensions;
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+
+using Cognite.Extensions;
 using Cognite.Extractor.StateStorage;
 using Cognite.Extractor.Utils;
 using Cognite.Simulator.Utils;
+
 using CogniteSdk;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Net.Http;
-using System.Threading;
+
 using Xunit;
 
 namespace Cognite.Simulator.Tests
@@ -78,7 +82,8 @@ namespace Cognite.Simulator.Tests
 
             // Configure OIDC auth
             services.AddHttpClient("AuthClient");
-            services.AddSingleton<IAuthenticator>(p => {
+            services.AddSingleton<IAuthenticator>(p =>
+            {
                 var factory = p.GetRequiredService<IHttpClientFactory>();
                 var logger = p.GetRequiredService<ILogger<IAuthenticator>>();
                 return new MsalAuthenticator(authConfig, logger, factory, "AuthClient");
@@ -86,11 +91,13 @@ namespace Cognite.Simulator.Tests
 
             // Configure CDF Client
             services.AddHttpClient<Client.Builder>()
-                .AddPolicyHandler((provider, message) => {
+                .AddPolicyHandler((provider, message) =>
+                {
                     return CogniteExtensions.GetRetryPolicy(null, 10, 10000);
                 });
-            
-            services.AddSingleton(p => {
+
+            services.AddSingleton(p =>
+            {
                 var auth = p.GetRequiredService<IAuthenticator>();
                 var builder = p.GetRequiredService<Client.Builder>();
                 var client = builder

--- a/Cognite.Simulator.Tests/DataProcessingTests/DataSamplingTest.cs
+++ b/Cognite.Simulator.Tests/DataProcessingTests/DataSamplingTest.cs
@@ -1,5 +1,7 @@
 using System;
+
 using Cognite.DataProcessing;
+
 using Xunit;
 
 namespace Cognite.Simulator.Tests.DataProcessingTests;
@@ -29,8 +31,8 @@ public class DataSamplingTest
         _unionResults = new TimeSeriesData(
             time: testData.UnionTimeExpected, data: testData.UnionDataExpected, granularity: 60000, isStep: false);
         _simpleSensor = new TimeSeriesData(
-            time: new long[] {2, 4, 5, 8, 8, 10, 11, 12, 14, 15, 17, 18},
-            data: new double[] {1, 1, 2, 3, 5, 6, 5, 5, 3.5, 3.2, 3.1, 1},
+            time: new long[] { 2, 4, 5, 8, 8, 10, 11, 12, 14, 15, 17, 18 },
+            data: new double[] { 1, 1, 2, 3, 5, 6, 5, 5, 3.5, 3.2, 3.1, 1 },
             granularity: 1,
             isStep: false);
         _oneDataPoint = new TimeSeriesData(
@@ -48,7 +50,7 @@ public class DataSamplingTest
         _check1 = testData.Check1;
         _threshold1 = testData.Threshold1;
     }
-    
+
     [Fact]
     public void TestUnionLogicTimeSeries()
     {
@@ -61,7 +63,7 @@ public class DataSamplingTest
             Assert.Equal(_unionResults.Data[i], unionTs.Data[i]);
         }
     }
-    
+
     [Fact]
     public void TestUnionLogicTimeSeries1()
     {
@@ -71,17 +73,17 @@ public class DataSamplingTest
         Assert.Throws<ArgumentException>(() => DataSampling.UnionLogicTimeSeries(
             ts1: _simpleSensor, ts2: _oneDataPoint));
     }
-    
+
     [Fact]
     public void TestUnionLogicTimeSeries2()
     {
         // as the time series with one datapoint is configured as step, we can extrapolate and a feasible union is found
         // 1) IsStep: true  { x  o  o  o  o  o  ... }
         // 2) IsStep: false       { x  x  x  x  ... }
-        
+
         // Call Method
         TimeSeriesData unionTs = DataSampling.UnionLogicTimeSeries(ts1: _simpleSensor, ts2: _oneDataPointStep);
-        
+
         // Expected
         TimeSeriesData expectedTs = new(
             time: new long[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 },
@@ -95,13 +97,13 @@ public class DataSamplingTest
             Assert.Equal(expectedTs.Data[i], unionTs.Data[i]);
         }
     }
-    
+
     [Fact]
     public void TestUnionLogicTimeSeries3()
     {
         // Call Method
         TimeSeriesData unionTs = DataSampling.UnionLogicTimeSeries(ts1: _simpleSensor, ts2: _twoDataPoints);
-        
+
         // Expected
         TimeSeriesData expectedTs = new(
             time: new long[] { 2, 3, 4, 5, 6, 7, 8, 9, 10 },
@@ -115,13 +117,13 @@ public class DataSamplingTest
             Assert.Equal(expectedTs.Data[i], unionTs.Data[i]);
         }
     }
-    
+
     [Fact]
     public void TestUnionLogicTimeSeries4()
     {
         // Call Method
         TimeSeriesData unionTs = DataSampling.UnionLogicTimeSeries(ts1: _simpleSensor, ts2: _twoDataPointsStep);
-        
+
         // Expected
         TimeSeriesData expectedTs = new(
             time: new long[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 },
@@ -150,7 +152,7 @@ public class DataSamplingTest
 
         if (sampleTime != null) Assert.Equal(expectedSampleTime, sampleTime.Value);
     }
-    
+
     [Fact]
     public void TestLogicalCheck()
     {
@@ -164,17 +166,17 @@ public class DataSamplingTest
             Assert.Equal(_logicalCheck1.Data[i], logicResult.Data[i]);
         }
     }
-    
+
     [Fact]
     public void TestLogicalCheckExtrapolate()
     {
         // input data
         TimeSeriesData input = new TimeSeriesData(
-            time: new long[] {1, 2, 3}, data: new double[] {5, 0, 3}, granularity: 1, isStep: true);
+            time: new long[] { 1, 2, 3 }, data: new double[] { 5, 0, 3 }, granularity: 1, isStep: true);
 
         TimeSeriesData output = new TimeSeriesData(
-            time: new long[] {1, 2, 3, 4, 5}, data: new double[] {1, 0, 1, 1, 1}, granularity: 1, isStep: true);
-        
+            time: new long[] { 1, 2, 3, 4, 5 }, data: new double[] { 1, 0, 1, 1, 1 }, granularity: 1, isStep: true);
+
         // Call Method
         TimeSeriesData logicResult = DataSampling.LogicalCheck(
             ts: input, threshold: 2.5, check: DataSampling.LogicOperator.Ge, endTime: 5);
@@ -185,17 +187,17 @@ public class DataSamplingTest
             Assert.Equal(output.Data[i], logicResult.Data[i]);
         }
     }
-    
+
     [Fact]
     public void TestLogicalCheckTryExtrapolate()
     {
         // input data
         TimeSeriesData input = new TimeSeriesData(
-            time: new long[] {1, 2, 3}, data: new double[] {5, 0, 3}, granularity: 1, isStep: false);
+            time: new long[] { 1, 2, 3 }, data: new double[] { 5, 0, 3 }, granularity: 1, isStep: false);
 
         TimeSeriesData output = new TimeSeriesData(
-            time: new long[] {1, 2, 3}, data: new double[] {1, 0, 1}, granularity: 1, isStep: false);
-        
+            time: new long[] { 1, 2, 3 }, data: new double[] { 1, 0, 1 }, granularity: 1, isStep: false);
+
         // Call Method
         TimeSeriesData logicResult = DataSampling.LogicalCheck(
             ts: input, threshold: 2.5, check: DataSampling.LogicOperator.Ge, endTime: 5);

--- a/Cognite.Simulator.Tests/DataProcessingTests/DetectorsTest.cs
+++ b/Cognite.Simulator.Tests/DataProcessingTests/DetectorsTest.cs
@@ -1,4 +1,5 @@
 using Cognite.DataProcessing;
+
 using Xunit;
 
 namespace Cognite.Simulator.Tests.DataProcessingTests;
@@ -15,7 +16,7 @@ public class DetectorsTest
         // shared test inputs
         _data = new double[] { 1, 1, 1, 1, 10, 10, 10, 10, 10, 1, 1, 1, 1 };
         _minDistance = 1;
-        
+
         var testData = new TestValues();
         _sensorSsd = new TimeSeriesData(
             time: testData.TimeSsd, data: testData.DataSsd, granularity: 60000, isStep: false);
@@ -35,7 +36,7 @@ public class DetectorsTest
         for (int i = 0; i < expected.Length; i++)
             Assert.Equal(expected[i], changePoints[i]);
     }
-    
+
     [Fact]
     public void TestSsd()
     {

--- a/Cognite.Simulator.Tests/DataProcessingTests/OptimizersTest.cs
+++ b/Cognite.Simulator.Tests/DataProcessingTests/OptimizersTest.cs
@@ -1,5 +1,7 @@
 using System;
+
 using Cognite.DataProcessing;
+
 using Xunit;
 
 namespace Cognite.Simulator.Tests.DataProcessingTests;
@@ -33,13 +35,13 @@ public class OptimizersTest
         // minimum at 1.5
         calcRoot = Optimizers.MinimizeScalarBounded(_testFunction2, 1, 5);
         Assert.Equal(1.5, calcRoot.X, 4);
-        
+
         // minimum at 0.8164965876370768
         calcRoot = Optimizers.MinimizeScalarBounded(_testFunction3, -5, 5);
         Assert.Equal(0.8164965876370768, calcRoot.X, 4);
         calcRoot = Optimizers.MinimizeScalarBounded(_testFunction3, -2, 4);
         Assert.Equal(0.8164965876370768, calcRoot.X, 4);
-        
+
         // minimum at -2
         calcRoot = Optimizers.MinimizeScalarBounded(_testFunction4, -2, -1);
         Assert.Equal(-2, calcRoot.X, 4);

--- a/Cognite.Simulator.Tests/DataProcessingTests/TestValues.cs
+++ b/Cognite.Simulator.Tests/DataProcessingTests/TestValues.cs
@@ -617,7 +617,7 @@ public class TestValues
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
     };
-    
+
     // Logical check
     public long[] LogicalCheckTime { get; } = new long[]
     {
@@ -728,7 +728,7 @@ public class TestValues
 
     public DataSampling.LogicOperator Check1 { get; } = DataSampling.LogicOperator.Ge;
     public double Threshold1 { get; } = 2300.0;
-    
+
     public double[] LogicalCheckData1 { get; } = new double[]
     {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/Cognite.Simulator.Tests/DataProcessingTests/TimeSeriesUtilsTest.cs
+++ b/Cognite.Simulator.Tests/DataProcessingTests/TimeSeriesUtilsTest.cs
@@ -1,5 +1,7 @@
 using System;
+
 using Cognite.DataProcessing;
+
 using Xunit;
 
 namespace Cognite.Simulator.Tests.DataProcessingTests;
@@ -19,13 +21,13 @@ public class TimeSeriesUtilsTest
         double[] dataArray1 = new double[] { 1, 2, 5, 6, 8 };
         _tsTest1 = new TimeSeriesData(timeArray1, dataArray1, 1);
         _tsTestStep1 = new TimeSeriesData(timeArray1, dataArray1, 1, true);
-            
-        long[] timeArray2 = new long[]{ 2, 4, 5, 8, 8, 10, 11, 12, 14, 15, 17, 18 };
+
+        long[] timeArray2 = new long[] { 2, 4, 5, 8, 8, 10, 11, 12, 14, 15, 17, 18 };
         double[] dataArray2 = new double[] { 1.0, 1.0, 2.0, 3.0, 5.0, 6.0, 5.0, 5.0, 3.5, 3.2, 3.1, 1.0 };
         _tsTest2 = new TimeSeriesData(timeArray2, dataArray2, 1);
         _tsTestStep2 = new TimeSeriesData(timeArray2, dataArray2, 1, true);
     }
-    
+
     [Fact]
     public void TestMinMax()
     {
@@ -53,7 +55,7 @@ public class TimeSeriesUtilsTest
             Assert.Equal(dataArrayResampled[i], tsResampled.Data[i]);
         }
     }
-    
+
     [Fact]
     public void TestTimeSeriesInterpolation2()
     {
@@ -87,7 +89,7 @@ public class TimeSeriesUtilsTest
             Assert.Equal(dataArrayResampled[i], tsResampled.Data[i], 4);
         }
     }
-    
+
     [Fact]
     public void TestTimeSeriesStepInterpolation2()
     {
@@ -104,7 +106,7 @@ public class TimeSeriesUtilsTest
             Assert.Equal(dataArrayResampled[i], tsResampled.Data[i], 4);
         }
     }
-    
+
     [Fact]
     public void TestTimeSeriesStepInterpolationExtrapolate()
     {
@@ -112,7 +114,7 @@ public class TimeSeriesUtilsTest
         TimeSeriesData tsResampled = _tsTestStep1.EquallySpacedResampling(endTime: 10);
 
         // Expected results
-        long[] timeArrayResampled = new long[] { 1, 2, 3, 4, 5, 6, 7, 8 , 9, 10};
+        long[] timeArrayResampled = new long[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         double[] dataArrayResampled = new double[] { 1, 2, 2, 2, 5, 6, 6, 8, 8, 8 };
 
         for (int i = 0; i < timeArrayResampled.Length; i++)
@@ -121,7 +123,7 @@ public class TimeSeriesUtilsTest
             Assert.Equal(dataArrayResampled[i], tsResampled.Data[i]);
         }
     }
-    
+
     [Fact]
     public void TestTimeSeriesInterpolationExtrapolate()
     {
@@ -169,7 +171,7 @@ public class TimeSeriesUtilsTest
         double[] dataArray1 = new double[] { 1, 2, 5, 6, 8 };
         TimeSeriesData ts1 = new(timeArray1, dataArray1, 1);
 
-        long[] timeArray2 = new long[] { 2, 5, 6, 7, 8, 9};
+        long[] timeArray2 = new long[] { 2, 5, 6, 7, 8, 9 };
         double[] dataArray2 = new double[] { 4, 10, 12, 14, 16, 18 };
         TimeSeriesData ts2 = new(timeArray2, dataArray2, 1);
 
@@ -178,7 +180,7 @@ public class TimeSeriesUtilsTest
 
         // Expected results
         TimeSeriesData alignedTs1 = new(
-            new long[]{ 2, 3, 4, 5, 6, 7, 8}, new double[]{2, 3, 4, 5, 6, 7, 8 }, 1
+            new long[] { 2, 3, 4, 5, 6, 7, 8 }, new double[] { 2, 3, 4, 5, 6, 7, 8 }, 1
         );
         TimeSeriesData alignedTs2 = new(
             new long[] { 2, 3, 4, 5, 6, 7, 8 }, new double[] { 4, 6, 8, 10, 12, 14, 16 }, 1

--- a/Cognite.Simulator.Tests/ExtensionsTests/DataPointsTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/DataPointsTest.cs
@@ -1,8 +1,12 @@
-using Cognite.Simulator.Extensions;
-using CogniteSdk;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Threading.Tasks;
+
+using Cognite.Simulator.Extensions;
+
+using CogniteSdk;
+
+using Microsoft.Extensions.DependencyInjection;
+
 using Xunit;
 
 namespace Cognite.Simulator.Tests.ExtensionsTests
@@ -49,19 +53,19 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             var cdf = provider.GetRequiredService<Client>();
             var dataPoints = cdf.DataPoints;
 
-            await SeedData.GetOrCreateTestTimeseries(cdf).ConfigureAwait(false);
+            await SeedData.GetOrCreateTestTimeseries(cdf);
 
             // Tests assume the given time series exists in the test project and
             // that it contains data points in this time range
             var samplingConfiguration = new SamplingConfiguration(start: 1631294940000, end: 1631296740000);
-            
+
             // Test max aggregation. A single data point should be returned
             var (timestamps, values) = await dataPoints.GetSample(
                 "utils-tests-OnOffValues",
                 Extensions.DataPointAggregate.Max,
                 800,
                 samplingConfiguration,
-                System.Threading.CancellationToken.None).ConfigureAwait(false);
+                System.Threading.CancellationToken.None);
             Assert.NotNull(timestamps);
             Assert.NotNull(values);
             Assert.Single(values);
@@ -86,15 +90,16 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                 Extensions.DataPointAggregate.StepInterpolation,
                 1,
                 range2,
-                System.Threading.CancellationToken.None).ConfigureAwait(false);
+                System.Threading.CancellationToken.None);
             Assert.NotNull(timestamps2);
             Assert.NotNull(values2);
             Assert.Single(values2);
             Assert.Equal(1, values2[0]);
         }
-        
+
         [Fact]
-        public async Task TestGetSampleNoDataSampling() {
+        public async Task TestGetSampleNoDataSampling()
+        {
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
 
@@ -104,12 +109,12 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
 
             // DataSampling disabled range
             var currentTimeEpoch = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            var disabledDataSampling = new SamplingConfiguration( end: currentTimeEpoch );
+            var disabledDataSampling = new SamplingConfiguration(end: currentTimeEpoch);
             var (timestamp, value) = await dataPoints.GetLatestValue(
                 "utils-tests-OnOffValues",
                 disabledDataSampling,
-                System.Threading.CancellationToken.None).ConfigureAwait(false);
-            
+                System.Threading.CancellationToken.None);
+
             Assert.Equal(1, value);
         }
     }

--- a/Cognite.Simulator.Tests/ExtensionsTests/TimeSeriesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/TimeSeriesTest.cs
@@ -3,11 +3,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CogniteSdk;
-using Microsoft.Extensions.DependencyInjection;
-using Xunit;
-
 using Cognite.Simulator.Extensions;
+
+using CogniteSdk;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit;
 
 namespace Cognite.Simulator.Tests.ExtensionsTests
 {
@@ -58,7 +60,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                     {
                         { "sourceAddress", "TEST.IN.B" }
                     },
-                SaveTimeseriesExternalId = "TestSimulator-Input_B-TestCalc-CTM" 
+                SaveTimeseriesExternalId = "TestSimulator-Input_B-TestCalc-CTM"
             };
 
             var inputs = new List<SimulationInput>
@@ -79,7 +81,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                     },
                 SaveTimeseriesExternalId = "TestSimulator-Output_A-TestCalc-GasRate"
             };
-            var outputs = new List<SimulationOutput> { 
+            var outputs = new List<SimulationOutput> {
                 outA
             };
 
@@ -95,7 +97,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                 var inputTs = await timeSeries.GetOrCreateSimulationInputs(
                     inputs,
                     dataSetId,
-                    CancellationToken.None).ConfigureAwait(false);
+                    CancellationToken.None);
                 Assert.True(inputTs.Any());
                 Assert.Equal(2, inputTs.Count());
                 var inTsA = inputTs.First(ts => ts.ExternalId == inA.SaveTimeseriesExternalId);
@@ -117,7 +119,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                 var outputTs = await timeSeries.GetOrCreateSimulationOutputs(
                     outputs,
                     dataSetId,
-                    CancellationToken.None).ConfigureAwait(false);
+                    CancellationToken.None);
                 Assert.Single(outputTs);
                 var outTsA = outputTs.First(ts => ts.ExternalId == outA.SaveTimeseriesExternalId);
                 Assert.Equal(outA.Unit, outTsA.Unit);
@@ -137,7 +139,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
                     {
                         IgnoreUnknownIds = true,
                         Items = tsToDelete,
-                    }, CancellationToken.None).ConfigureAwait(false);
+                    }, CancellationToken.None);
                 }
 
             }

--- a/Cognite.Simulator.Tests/SeedData.cs
+++ b/Cognite.Simulator.Tests/SeedData.cs
@@ -1,17 +1,18 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
+
+using Cognite.Extractor.Common;
+using Cognite.Simulator.Tests.DataProcessingTests;
+using Cognite.Simulator.Utils;
 
 using CogniteSdk;
 using CogniteSdk.Alpha;
-using Com.Cognite.V1.Timeseries.Proto;
 
-using Cognite.Simulator.Tests.DataProcessingTests;
-using Cognite.Simulator.Utils;
-using Cognite.Extractor.Common;
+using Com.Cognite.V1.Timeseries.Proto;
 
 namespace Cognite.Simulator.Tests
 {
@@ -59,7 +60,7 @@ namespace Cognite.Simulator.Tests
 
             // delete all test simulators older than 3 minutes and the one with the given externalId
             var createdTime = DateTime.UtcNow.AddMinutes(-3).ToUnixTimeMilliseconds();
-            var simulatorRes = simulators.Items.Where(s => 
+            var simulatorRes = simulators.Items.Where(s =>
                 (s.ExternalId.StartsWith(TestSimulatorExternalIdPrefix) && s.CreatedTime < createdTime) || s.ExternalId == externalId
             );
             if (simulatorRes.Count() > 0)
@@ -107,13 +108,15 @@ namespace Cognite.Simulator.Tests
             return res.First();
         }
 
-        public static FileCreate SimpleModelFileCreate = new FileCreate() {
+        public static FileCreate SimpleModelFileCreate = new FileCreate()
+        {
             Name = "simutils-tests-model.out",
             ExternalId = "simutils-tests-model-single-byte",
             DataSetId = TestDataSetId,
         };
 
-        public static FileCreate SimpleModelFileCreate2 = new FileCreate() {
+        public static FileCreate SimpleModelFileCreate2 = new FileCreate()
+        {
             Name = "simutils-tests-model-2.out",
             ExternalId = "simutils-tests-model-single-byte-2",
             DataSetId = TestDataSetId,
@@ -152,7 +155,8 @@ namespace Cognite.Simulator.Tests
             var uploadUrl = res.UploadUrl;
             var bytes = new byte[1] { 42 };
 
-            using (var fileStream = new StreamContent(new MemoryStream(bytes))) {
+            using (var fileStream = new StreamContent(new MemoryStream(bytes)))
+            {
                 await fileStorageClient.UploadFileAsync(uploadUrl, fileStream).ConfigureAwait(false);
             }
 
@@ -163,11 +167,14 @@ namespace Cognite.Simulator.Tests
         {
             await GetOrCreateSimulatorModel(sdk, model).ConfigureAwait(false);
 
-            try {
+            try
+            {
                 var rev = await sdk.Alpha.Simulators.RetrieveSimulatorModelRevisionsAsync(
                     new List<Identity> { new Identity(revision.ExternalId) }).ConfigureAwait(false);
                 return rev.First();
-            } catch {
+            }
+            catch
+            {
                 var res = await sdk.Alpha.Simulators.CreateSimulatorModelRevisionsAsync(
                 new List<SimulatorModelRevisionCreate>
                 {
@@ -184,7 +191,8 @@ namespace Cognite.Simulator.Tests
             return await GetOrCreateSimulatorModelRevision(sdk, SimulatorModelCreate, revision).ConfigureAwait(false);
         }
 
-        public static async Task<List<SimulatorModelRevision>> GetOrCreateSimulatorModelRevisions(Client sdk, FileStorageClient fileStorageClient) {            
+        public static async Task<List<SimulatorModelRevision>> GetOrCreateSimulatorModelRevisions(Client sdk, FileStorageClient fileStorageClient)
+        {
             var rev1 = await GetOrCreateSimulatorModelRevisionWithFile(sdk, fileStorageClient, SimpleModelFileCreate, SimulatorModelRevisionCreateV1).ConfigureAwait(false);
             var rev2 = await GetOrCreateSimulatorModelRevisionWithFile(sdk, fileStorageClient, SimpleModelFileCreate2, SimulatorModelRevisionCreateV2).ConfigureAwait(false);
             return new List<SimulatorModelRevision> { rev1, rev2 };
@@ -227,12 +235,16 @@ namespace Cognite.Simulator.Tests
             DataSetId = TestDataSetId,
         };
 
-        public static async Task<TimeSeries> GetOrCreateTimeSeries(Client sdk, TimeSeriesCreate timeSeries) {
-            try {
+        public static async Task<TimeSeries> GetOrCreateTimeSeries(Client sdk, TimeSeriesCreate timeSeries)
+        {
+            try
+            {
                 var res = await sdk.TimeSeries.CreateAsync(
                 new List<TimeSeriesCreate> { timeSeries }).ConfigureAwait(false);
                 return res.First();
-            } catch (ResponseException e) when (e.Code == 409) {
+            }
+            catch (ResponseException e) when (e.Code == 409)
+            {
                 var timeSeriesRes = await sdk.TimeSeries.RetrieveAsync(
                     new List<string>() { timeSeries.ExternalId }, true
                 ).ConfigureAwait(false);
@@ -605,7 +617,7 @@ namespace Cognite.Simulator.Tests
                 },
                 SteadyStateDetection = new List<SimulatorRoutineRevisionSteadyStateDetection>()
                 {
-                    new SimulatorRoutineRevisionSteadyStateDetection 
+                    new SimulatorRoutineRevisionSteadyStateDetection
                     {
                         Enabled = true,
                         TimeseriesExternalId = "utils-tests-SsdSensorData",
@@ -818,7 +830,8 @@ namespace Cognite.Simulator.Tests
 
         public static SimulatorModelRevisionCreate SimulatorModelRevisionCreateV2 = GenerateSimulatorModelRevisionCreate(TestModelExternalId, 2);
 
-        public static SimulatorModelRevisionCreate GenerateSimulatorModelRevisionCreate(string externalId, int version = 1) {
+        public static SimulatorModelRevisionCreate GenerateSimulatorModelRevisionCreate(string externalId, int version = 1)
+        {
             return new SimulatorModelRevisionCreate()
             {
                 ExternalId = $"{externalId}-{version}",
@@ -830,8 +843,8 @@ namespace Cognite.Simulator.Tests
         public static SimulatorCreate SimulatorCreate = new SimulatorCreate()
         {
             ExternalId = TestSimulatorExternalId,
-            Name =  TestSimulatorExternalId,
-            FileExtensionTypes= new List<string> { "out" },
+            Name = TestSimulatorExternalId,
+            FileExtensionTypes = new List<string> { "out" },
             StepFields = new List<SimulatorStepField> {
                 new SimulatorStepField {
                     StepType = "get/set",

--- a/Cognite.Simulator.Tests/TestHelpers.cs
+++ b/Cognite.Simulator.Tests/TestHelpers.cs
@@ -2,24 +2,31 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Cognite.Extractor.Common;
+
 using CogniteSdk;
 using CogniteSdk.Alpha;
 
-namespace Cognite.Simulator.Tests {
-    public class TestHelpers {
-        
-        public static async Task SimulateASimulatorRunning(Client cdf, string connectorName = "scheduler-test-connector" ) {
+namespace Cognite.Simulator.Tests
+{
+    public class TestHelpers
+    {
+
+        public static async Task SimulateASimulatorRunning(Client cdf, string connectorName = "scheduler-test-connector")
+        {
             var integrations = await cdf.Alpha.Simulators.ListSimulatorIntegrationsAsync(
                 new SimulatorIntegrationQuery
                 {
-                    Filter = new SimulatorIntegrationFilter() {
+                    Filter = new SimulatorIntegrationFilter()
+                    {
                         SimulatorExternalIds = new List<string> { SeedData.TestSimulatorExternalId },
                     }
                 }
             ).ConfigureAwait(false);
             var existing = integrations.Items.FirstOrDefault(i => i.ExternalId == connectorName);
-            if (existing == null) {
+            if (existing == null)
+            {
                 await cdf.Alpha.Simulators.CreateSimulatorIntegrationAsync(
                     new List<SimulatorIntegrationCreate>
                     {
@@ -34,7 +41,9 @@ namespace Cognite.Simulator.Tests {
                         }
                     }
                 ).ConfigureAwait(false);
-            } else {
+            }
+            else
+            {
                 await cdf.Alpha.Simulators.UpdateSimulatorIntegrationAsync(
                     new List<SimulatorIntegrationUpdateItem>
                     {

--- a/Cognite.Simulator.Tests/UtilsTests/CommonUtilsTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/CommonUtilsTest.cs
@@ -1,12 +1,16 @@
-﻿using Cognite.Extractor.Common;
-using Cognite.Simulator.Utils;
-using CogniteSdk;
-using CogniteSdk.Alpha;
-using Microsoft.Extensions.DependencyInjection;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
+using Cognite.Extractor.Common;
+using Cognite.Simulator.Utils;
+
+using CogniteSdk;
+using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.DependencyInjection;
+
 using Xunit;
 
 namespace Cognite.Simulator.Tests.UtilsTests
@@ -33,7 +37,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var cdf = provider.GetRequiredService<Client>();
             var dataPoints = cdf.DataPoints;
 
-            await SeedData.GetOrCreateTestTimeseries(cdf).ConfigureAwait(false);
+            await SeedData.GetOrCreateTestTimeseries(cdf);
 
             var config = NewRoutineConfig();
             config.LogicalCheck.First().Enabled = runLogicCheck;
@@ -43,7 +47,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 dataPoints,
                 config,
                 CogniteTime.FromUnixTimeMilliseconds(validationEnd),
-                System.Threading.CancellationToken.None).ConfigureAwait(false);
+                System.Threading.CancellationToken.None);
 
             Assert.True(result.Min.HasValue);
             Assert.Equal(expectedStart, result.Min.Value);

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorBaseTest.cs
@@ -1,15 +1,19 @@
-﻿using Cognite.Extractor.Common;
-using Cognite.Extractor.Utils;
-using Cognite.Simulator.Utils;
-using Cognite.Simulator.Utils.Automation;
-using CogniteSdk;
-using CogniteSdk.Alpha;
-using Microsoft.Extensions.DependencyInjection;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Cognite.Extractor.Common;
+using Cognite.Extractor.Utils;
+using Cognite.Simulator.Utils;
+using Cognite.Simulator.Utils.Automation;
+
+using CogniteSdk;
+using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.DependencyInjection;
+
 using Xunit;
 
 namespace Cognite.Simulator.Tests.UtilsTests
@@ -43,17 +47,17 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var cdf = provider.GetRequiredService<Client>();
             var cdfConfig = provider.GetRequiredService<CogniteConfig>();
 
-            await SeedData.GetOrCreateSimulator(cdf, SeedData.SimulatorCreate).ConfigureAwait(false);
+            await SeedData.GetOrCreateSimulator(cdf, SeedData.SimulatorCreate);
 
             try
             {
                 await connector
                     .Init(source.Token)
-                    .ConfigureAwait(false);
+;
 
                 var integrationsRes = await cdf.Alpha.Simulators.ListSimulatorIntegrationsAsync(
                     new SimulatorIntegrationQuery(),
-                    source.Token).ConfigureAwait(false);
+                    source.Token);
                 var integration = integrationsRes.Items.FirstOrDefault(i => i.SimulatorExternalId == SeedData.TestSimulatorExternalId);
 
                 Assert.NotNull(integration);
@@ -69,22 +73,24 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(source.Token);
                 var linkedToken = linkedTokenSource.Token;
                 linkedTokenSource.CancelAfter(TimeSpan.FromSeconds(5));
-                await connector.Run(linkedToken).ConfigureAwait(false);
+                await connector.Run(linkedToken);
 
                 var pipelines = await cdf.ExtPipes.RetrieveAsync(
                     new List<string> { cdfConfig.ExtractionPipeline.PipelineId },
                     true,
-                    source.Token).ConfigureAwait(false);
+                    source.Token);
                 Assert.Contains(pipelines, p => p.ExternalId == cdfConfig.ExtractionPipeline.PipelineId);
                 Assert.Contains(pipelines, p => p.LastSeen >= timestamp);
             }
             finally
             {
-                await SeedData.DeleteSimulator(cdf, SeedData.TestSimulatorExternalId).ConfigureAwait(false);
-                try {
+                await SeedData.DeleteSimulator(cdf, SeedData.TestSimulatorExternalId);
+                try
+                {
                     await cdf.ExtPipes
-                        .DeleteAsync(new []{ cdfConfig.ExtractionPipeline?.PipelineId }, CancellationToken.None); 
-                } catch (Exception) {}
+                        .DeleteAsync(new[] { cdfConfig.ExtractionPipeline?.PipelineId }, CancellationToken.None);
+                }
+                catch (Exception) { }
             }
         }
     }
@@ -96,7 +102,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
     /// </summary>
     internal class TestConnector : ConnectorBase<Utils.BaseConfig>
     {
-        static ConnectorConfig TestConnectorConfig = new ConnectorConfig() {
+        static ConnectorConfig TestConnectorConfig = new ConnectorConfig()
+        {
             NamePrefix = $"Test Connector {DateTime.UtcNow.ToUnixTimeMilliseconds()}",
             AddMachineNameSuffix = false,
             StatusInterval = 2,
@@ -146,8 +153,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
             {
                 var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
                 var linkedToken = linkedTokenSource.Token;
-                var taskList = new List<Task> 
-                { 
+                var taskList = new List<Task>
+                {
                     HeartbeatLoop(linkedToken),
                     _pipeline.PipelineUpdate(linkedToken)
                 };

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
@@ -1,20 +1,22 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Moq;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Xunit;
-
+using Cognite.Extractor.Logging;
 using Cognite.Simulator.Utils;
+using Cognite.Simulator.Utils.Automation;
+
 using CogniteSdk.Alpha;
 
-using Cognite.Simulator.Utils.Automation;
-using Cognite.Extractor.Logging;
-using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
 
 using static Cognite.Simulator.Tests.UtilsTests.TestUtilities;
 
@@ -50,17 +52,20 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var mocks = GetMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
             var mockFactory = mocks.factory;
 
-            DefaultConnectorRuntime<DefaultAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.ConfigureServices = (services) => {
+            DefaultConnectorRuntime<DefaultAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.ConfigureServices = (services) =>
+            {
                 services.AddScoped<ISimulatorClient<DefaultModelFilestate, SimulatorRoutineRevision>, EmptySimulatorAutomationClient>();
                 services.AddSingleton(mockFactory.Object);
                 services.AddSingleton(mockedLogger.Object);
             };
             DefaultConnectorRuntime<DefaultAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.ConnectorName = "Empty";
             DefaultConnectorRuntime<DefaultAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.SimulatorDefinition = SeedData.SimulatorCreate;
-            
-            try {
-                await DefaultConnectorRuntime<DefaultAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.Run(logger, cts.Token).ConfigureAwait(false);
-            } catch (OperationCanceledException) {}
+
+            try
+            {
+                await DefaultConnectorRuntime<DefaultAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.Run(logger, cts.Token);
+            }
+            catch (OperationCanceledException) { }
 
             // Check the logs, it should first succeed on the startup, then fail and restart
             VerifyLog(mockedLogger, LogLevel.Information, "Starting the connector...", Times.Once());
@@ -118,7 +123,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
         internal class CalculatorRoutineAutomation : RoutineImplementationBase
         {
-            public CalculatorRoutineAutomation(SimulatorRoutineRevision routineRevision, Dictionary<string, SimulatorValueItem> inputData, ILogger logger) : base(routineRevision, inputData, logger )
+            public CalculatorRoutineAutomation(SimulatorRoutineRevision routineRevision, Dictionary<string, SimulatorValueItem> inputData, ILogger logger) : base(routineRevision, inputData, logger)
             {
             }
 

--- a/Cognite.Simulator.Tests/UtilsTests/ExtPipelineUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ExtPipelineUnitTest.cs
@@ -1,16 +1,16 @@
 ﻿using System;
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Cognite.Simulator.Utils;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using Moq;
-using Xunit;
 
-using Cognite.Simulator.Utils;
+using Xunit;
 
 using static Cognite.Simulator.Tests.UtilsTests.TestUtilities;
 
@@ -59,7 +59,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 PipelineNotification = new PipelineNotificationConfig(),
             };
             services.AddExtractionPipeline(connectorConfig);
-            
+
             using var provider = services.BuildServiceProvider();
 
             var extPipeline = provider.GetRequiredService<ExtractionPipeline>();

--- a/Cognite.Simulator.Tests/UtilsTests/FileStorageClientUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileStorageClientUnitTest.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
-
-using Moq;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Xunit;
 
 using Cognite.Simulator.Utils;
 
-using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
 
 using static Cognite.Simulator.Tests.UtilsTests.TestUtilities;
 
@@ -83,7 +84,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var client = services.BuildServiceProvider().GetRequiredService<FileStorageClient>();
 
             await Assert.ThrowsAsync<ConnectorException>(async () => await client.DownloadFileAsync(new Uri("http://localhost/files/download"), "test.txt", true));
-            
+
             VerifyLog(mockedLogger, LogLevel.Warning, $"File size exceeds the maximum allowed size to be downloded now, but can still be downloaded later: {FileStorageClient.LargeFileSize} bytes, actual size: {FileStorageClient.LargeFileSize + 1}", Times.Once(), true);
         }
     }

--- a/Cognite.Simulator.Tests/UtilsTests/ProcessUtilsTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ProcessUtilsTest.cs
@@ -1,14 +1,19 @@
-using Microsoft.Extensions.Logging;
-using Moq;
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Management;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-using Xunit;
+
 using Cognite.Simulator.Utils;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
 using static Cognite.Simulator.Tests.UtilsTests.TestUtilities;
-using System.Linq;
 
 namespace Cognite.Simulator.Tests.UtilsTests
 {
@@ -42,8 +47,9 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 Assert.Throws<PlatformNotSupportedException>(() => ProcessUtils.GetCurrentUsername());
             }
         }
-        
-        private bool IsProcessRunning(string processName, Process process) {
+
+        private bool IsProcessRunning(string processName, Process process)
+        {
             try
             {
                 return Process.GetProcessesByName(processName).Any(p => p.Id == process.Id);
@@ -62,7 +68,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             // Arrange
             var mockLogger = new Mock<ILogger<ProcessUtilsTests>>();
             var processName = "notepad";
-            
+
             // Create test process to ensure at least one exists
             Process testProcess = null;
             testProcess = Process.Start(processName + ".exe");
@@ -73,7 +79,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             // Verify log messages were called with correct parameters
             VerifyLog(mockLogger, LogLevel.Debug, "Searching for process : " + processName, Times.Once(), true);
             VerifyLog(mockLogger, LogLevel.Information, "Killing process with PID", Times.Once(), true);
-            
+
 
             bool processStillRunning = IsProcessRunning(processName, testProcess);
             Assert.False(processStillRunning, "Process should have been terminated");
@@ -84,10 +90,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
         {
             // Arrange
             var mockLogger = new Mock<ILogger<ProcessUtilsTests>>();
-            
+
             // Act 
             Assert.Throws<Exception>(() => ProcessUtils.KillProcess("ThisProcessDoesNotExist_12345", mockLogger.Object));
-            
+
             VerifyLog(mockLogger, LogLevel.Error, "No processes found to kill for the current user", Times.Once(), true);
         }
 
@@ -97,10 +103,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
             // Arrange - get current process ID
             int processId = Process.GetCurrentProcess().Id;
-            
+
             // Act
             string owner = ProcessUtils.GetProcessOwnerWmi(processId);
-            
+
             // Assert
             Assert.Contains("\\", owner); // Owner format should be "domain\user"
         }

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunUnitTest.cs
@@ -1,46 +1,55 @@
-using CogniteSdk.Alpha;
-using Cognite.Simulator.Utils;
-using Xunit;
 using System;
+
 using Cognite.Extractor.Common;
+using Cognite.Simulator.Utils;
+
+using CogniteSdk.Alpha;
+
+using Xunit;
 
 namespace Cognite.Simulator.Tests.UtilsTests;
 
-public class SimulationRunUnitTest {
+public class SimulationRunUnitTest
+{
 
     [Fact]
-    public void TestRunReadinessTimeout (){
+    public void TestRunReadinessTimeout()
+    {
         {
-            var input = new SimulationRunItem(new SimulationRun() {
+            var input = new SimulationRunItem(new SimulationRun()
+            {
                 CreatedTime = DateTime.UtcNow.AddSeconds(-10).ToUnixTimeMilliseconds(),
                 Status = SimulationRunStatus.ready,
                 Id = 1,
             });
-            
+
             var ex = Assert.Throws<ConnectorException>(() => input.ValidateReadinessForExecution(1));
             Assert.Equal("Simulation has timed out because it is older than 1 second(s)", ex.Message);
         }
-        
+
         {
-            var input = new SimulationRunItem(new SimulationRun() {
+            var input = new SimulationRunItem(new SimulationRun()
+            {
                 CreatedTime = 0,
                 Status = SimulationRunStatus.ready,
                 Id = 1,
             });
-            
+
             var ex = Assert.Throws<ConnectorException>(() => input.ValidateReadinessForExecution());
             Assert.Equal("Simulation has timed out because it is older than 3600 second(s)", ex.Message);
         }
     }
 
     [Fact]
-    public void TestRunReadinessAlreadyRunning (){
-        var input = new SimulationRunItem(new SimulationRun() {
+    public void TestRunReadinessAlreadyRunning()
+    {
+        var input = new SimulationRunItem(new SimulationRun()
+        {
             CreatedTime = DateTime.UtcNow.ToUnixTimeMilliseconds(),
             Status = SimulationRunStatus.running,
             Id = 1,
         });
-        
+
         var ex = Assert.Throws<ConnectorException>(() => input.ValidateReadinessForExecution());
         Assert.Equal("Simulation entered unrecoverable state and failed", ex.Message);
     }

--- a/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/SimulationRunnerTest.cs
@@ -1,16 +1,20 @@
-﻿using Cognite.Extractor.StateStorage;
-using Cognite.Extractor.Utils;
-using Cognite.Simulator.Utils;
-using CogniteSdk;
-using CogniteSdk.Alpha;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Cognite.Extractor.StateStorage;
+using Cognite.Extractor.Utils;
+using Cognite.Simulator.Utils;
+
+using CogniteSdk;
+using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using Xunit;
 
 using DataPointsQuery = CogniteSdk.DataPointsQuery;
@@ -34,7 +38,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
     public class SimulationRunnerTest
     {
 
-        public static IEnumerable<object[]> InputParams => 
+        public static IEnumerable<object[]> InputParams =>
             new List<object[]>
             {
                 // 1. timeseries inputs
@@ -108,13 +112,14 @@ namespace Cognite.Simulator.Tests.UtilsTests
         [Theory]
         [MemberData(nameof(InputParams))]
         public async Task TestSimulationRunnerBase(
-            SimulatorRoutineCreateCommandItem createRoutineItem, 
+            SimulatorRoutineCreateCommandItem createRoutineItem,
             SimulatorRoutineRevisionCreate createRevisionItem,
             IEnumerable<SimulationInputOverride> inputOverrides,
             SimulatorValue expectedResult,
             bool checkTs,
             bool debugLog
-        ) {
+        )
+        {
             var services = new ServiceCollection();
             services.AddCogniteTestClient();
             services.AddHttpClient<FileStorageClient>();
@@ -140,7 +145,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var cdf = provider.GetRequiredService<Client>();
             var FileStorageClient = provider.GetRequiredService<FileStorageClient>();
 
-            await SeedData.GetOrCreateSimulator(cdf, SeedData.SimulatorCreate).ConfigureAwait(false);
+            await SeedData.GetOrCreateSimulator(cdf, SeedData.SimulatorCreate);
 
             await TestHelpers.SimulateASimulatorRunning(cdf, SeedData.TestIntegrationExternalId).ConfigureAwait(true);
 
@@ -150,7 +155,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 FileStorageClient,
                 createRoutineItem,
                 createRevisionItem
-            ).ConfigureAwait(false);
+            );
 
             try
             {
@@ -163,15 +168,15 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
                 // Run model and configuration libraries to fetch the test model and
                 // test simulation configuration from CDF
-                await modelLib.Init(source.Token).ConfigureAwait(false);
-                await configLib.Init(source.Token).ConfigureAwait(false);
+                await modelLib.Init(source.Token);
+                await configLib.Init(source.Token);
 
                 // models are only processed right before the run happens (because we don't run the tasks from ModelLibrary)
                 // so this should be empty
                 var processedModels = modelLib._state.Values.Where(m => m.FilePath != null && m.Processed);
                 Assert.Empty(processedModels);
 
-                var routineRevision = await configLib.GetRoutineRevision(revision.ExternalId).ConfigureAwait(false);
+                var routineRevision = await configLib.GetRoutineRevision(revision.ExternalId);
                 Assert.NotNull(routineRevision);
                 var configObj = routineRevision.Configuration;
                 Assert.NotNull(configObj);
@@ -192,12 +197,12 @@ namespace Cognite.Simulator.Tests.UtilsTests
                             Inputs = inputOverrides.Any() ? inputOverrides : null,
                             LogSeverity = debugLog ? "Debug" : null
                         }
-                    }, source.Token).ConfigureAwait(false);
+                    }, source.Token);
                 Assert.NotEmpty(runs);
                 var run = runs.First();
 
                 var modelRevisionRes = await cdf.Alpha.Simulators.RetrieveSimulatorModelRevisionsAsync(
-                    new List<Identity> { new Identity(run.ModelRevisionExternalId) }, source.Token).ConfigureAwait(false);
+                    new List<Identity> { new Identity(run.ModelRevisionExternalId) }, source.Token);
 
                 var modelRevision = modelRevisionRes.First();
 
@@ -206,13 +211,13 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 var linkedToken2 = linkedTokenSource2.Token;
                 linkedTokenSource2.CancelAfter(TimeSpan.FromSeconds(10));
                 var taskList2 = new List<Task> { runner.Run(linkedToken2) };
-                await taskList2.RunAll(linkedTokenSource2).ConfigureAwait(false);
+                await taskList2.RunAll(linkedTokenSource2);
 
                 Assert.Empty(modelLib._temporaryState); // temporary state should be empty after running the model as it cleans up automatically
                 Assert.Empty(Directory.GetFiles("./files/temp"));
 
                 var runUpdatedRes = await cdf.Alpha.Simulators.RetrieveSimulationRunsAsync(
-                    new List<long> { run.Id }, source.Token).ConfigureAwait(false);
+                    new List<long> { run.Id }, source.Token);
 
                 Assert.NotEmpty(runUpdatedRes);
                 var runUpdated = runUpdatedRes.First();
@@ -222,36 +227,38 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 var simulationTime = runUpdated.SimulationTime.Value;
 
                 var logsRes = await cdf.Alpha.Simulators.RetrieveSimulatorLogsAsync(
-                    new List<Identity> { new Identity(runUpdated.LogId.Value) }, source.Token).ConfigureAwait(false);
+                    new List<Identity> { new Identity(runUpdated.LogId.Value) }, source.Token);
 
                 // this test is not running the full connector runtime
                 // so logs are not being automatically sent to CDF
                 var logData = logsRes.First().Data;
                 Assert.Empty(logData);
 
-                await sink.Flush(cdf.Alpha.Simulators, CancellationToken.None).ConfigureAwait(false);
+                await sink.Flush(cdf.Alpha.Simulators, CancellationToken.None);
 
                 // check logs again after flushing
                 logsRes = await cdf.Alpha.Simulators.RetrieveSimulatorLogsAsync(
-                    new List<Identity> { new Identity(runUpdated.LogId.Value) }, source.Token).ConfigureAwait(false);
+                    new List<Identity> { new Identity(runUpdated.LogId.Value) }, source.Token);
 
                 var logResFirst = logsRes.First();
                 Assert.NotEmpty(logResFirst.Data);
                 var warningLogItem = logResFirst.Data.Where(l => l.Severity == "Warning").First();
                 Assert.Equal("Running a sample routine, not a real simulation", warningLogItem.Message);
-                
+
                 if (debugLog)
                 {
                     Assert.Equal("Debug", logResFirst.Severity); // Override min severity
                     var debugLogs = logResFirst.Data.Where(l => l.Severity == "Debug");
                     Assert.NotEmpty(debugLogs);
-                } else {
+                }
+                else
+                {
                     Assert.Null(logResFirst.Severity); // Default severity
                 }
 
                 // check inputs/outputs from the /runs/data/list endpoint
                 var runDataRes = await cdf.Alpha.Simulators.ListSimulationRunsDataAsync(
-                    new List<long> { run.Id }, source.Token).ConfigureAwait(false);
+                    new List<long> { run.Id }, source.Token);
                 Assert.NotEmpty(runDataRes);
                 var inputs = runDataRes.First().Inputs;
                 Assert.NotEmpty(inputs);
@@ -262,12 +269,15 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     {
                         Assert.Contains(input.TimeseriesExternalId, inTsIds);
                     }
-                    if (inputOverrides.Any(i => i.ReferenceId == input.ReferenceId)) {
+                    if (inputOverrides.Any(i => i.ReferenceId == input.ReferenceId))
+                    {
                         Assert.True(input.Overridden);
                         var inputValue = input.Value as SimulatorValue.Double;
                         var inputOverride = inputOverrides.First(i => i.ReferenceId == input.ReferenceId).Value as SimulatorValue.Double;
                         Assert.Equal(inputValue?.Value, inputOverride?.Value);
-                    } else {
+                    }
+                    else
+                    {
                         Assert.NotEqual(input.Overridden, true);
                     }
                 }
@@ -279,17 +289,18 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 Assert.Equal(expectedResult?.Type, resultValue.Type);
                 Assert.Equal(expectedResult, resultValue);
 
-                if (checkTs) {
+                if (checkTs)
+                {
                     Assert.True(outTsIds.Any());
                     Assert.True(inTsIds.Any());
 
                     // Check that output time series were created
-                    var outTs = await cdf.TimeSeries.RetrieveAsync(outTsIds, true, source.Token).ConfigureAwait(false);
+                    var outTs = await cdf.TimeSeries.RetrieveAsync(outTsIds, true, source.Token);
                     Assert.True(outTs.Any(), $"No output time series were created [{string.Join(",", outTsIds)}]");
                     Assert.Equal(outTsIds.Count, outTs.Count());
 
                     // Check that input time series were created
-                    var inTs = await cdf.TimeSeries.RetrieveAsync(inTsIds, true, source.Token).ConfigureAwait(false);
+                    var inTs = await cdf.TimeSeries.RetrieveAsync(inTsIds, true, source.Token);
                     Assert.True(inTs.Any(), $"No input time series were created [{string.Join(",", inTsIds)}]");
                     Assert.Equal(inTsIds.Count, inTs.Count());
 
@@ -303,7 +314,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                             {
                                 ExternalId = o.ExternalId
                             })
-                        }, source.Token).ConfigureAwait(false);
+                        }, source.Token);
                     Assert.True(outDps.Items.Any());
                     Assert.NotNull(SampleRoutine._output);
                     Assert.Equal(SampleRoutine._output, outDps.Items.First().NumericDatapoints.Datapoints.First().Value);
@@ -318,7 +329,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                             {
                                 ExternalId = i.ExternalId
                             })
-                        }, source.Token).ConfigureAwait(false);
+                        }, source.Token);
                     Assert.True(inDps.Items.Any());
                     Assert.NotEmpty(SampleRoutine._inputs);
                     Assert.Contains(inDps.Items.First().NumericDatapoints.Datapoints.First().Value, SampleRoutine._inputs);
@@ -332,7 +343,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     {
                         IgnoreUnknownIds = true,
                         Items = tsToDelete.Select(i => new Identity(i)).ToList()
-                    }, source.Token).ConfigureAwait(false);
+                    }, source.Token);
                 }
                 provider.Dispose(); // Dispose provider to also dispose managed services
                 if (Directory.Exists("./files"))
@@ -356,13 +367,13 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
         private ILogger _logger;
         public SampleRoutine(SimulatorRoutineRevision config, Dictionary<string, SimulatorValueItem> inputData, ILogger logger)
-            :base(config, inputData, logger)
+            : base(config, inputData, logger)
         {
             _inputs = new List<double>();
             _output = null;
             _logger = logger;
         }
-        
+
         public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments, CancellationToken token)
         {
             SimulatorValue outputValue;
@@ -376,18 +387,23 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
             if (outputConfig.ValueType == SimulatorValueType.DOUBLE)
             {
-                outputValue = new SimulatorValue.Double(_output.Value);   
-            } else if (outputConfig.ValueType == SimulatorValueType.STRING)
+                outputValue = new SimulatorValue.Double(_output.Value);
+            }
+            else if (outputConfig.ValueType == SimulatorValueType.STRING)
             {
                 outputValue = new SimulatorValue.String(_output.ToString());
-            } else {
+            }
+            else
+            {
                 throw new InvalidOperationException("Unsupported value type");
             }
-            return new SimulatorValueItem() {
+            return new SimulatorValueItem()
+            {
                 Value = outputValue,
                 ReferenceId = outputConfig.ReferenceId,
                 TimeseriesExternalId = outputConfig.SaveTimeseriesExternalId,
-                Unit = outputConfig.Unit != null ? new SimulatorValueUnit() {
+                Unit = outputConfig.Unit != null ? new SimulatorValueUnit()
+                {
                     Name = outputConfig.Unit.Name,
                 } : null,
                 ValueType = outputConfig.ValueType
@@ -400,12 +416,15 @@ namespace Cognite.Simulator.Tests.UtilsTests
             {
                 throw new ArgumentNullException(nameof(arguments));
             }
-            if(arguments.TryGetValue("command", out var cmd)) {
+            if (arguments.TryGetValue("command", out var cmd))
+            {
                 if (cmd == "Simulate")
                 {
                     _output = _inputs.Sum();
                 }
-            } else {
+            }
+            else
+            {
                 throw new InvalidOperationException("No command provided");
             }
         }
@@ -467,8 +486,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
         }
 
         public Task<Dictionary<string, SimulatorValueItem>> RunSimulation(
-            TestFileState modelState, 
-            SimulatorRoutineRevision simulationConfiguration, 
+            TestFileState modelState,
+            SimulatorRoutineRevision simulationConfiguration,
             Dictionary<string, SimulatorValueItem> inputData,
             CancellationToken token)
         {
@@ -484,7 +503,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
     }
 
     public class SampleSimulationRunner :
-        RoutineRunnerBase<DefaultAutomationConfig,TestFileState, SimulatorRoutineRevision>
+        RoutineRunnerBase<DefaultAutomationConfig, TestFileState, SimulatorRoutineRevision>
     {
         internal const string connectorName = "integration-tests-connector";
 

--- a/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
@@ -7,8 +7,10 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
+
 using Moq;
 using Moq.Protected;
+
 using Xunit;
 
 namespace Cognite.Simulator.Tests.UtilsTests
@@ -94,7 +96,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
         /// <exception cref="ArgumentNullException"></exception>
         public static Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> MockRequestsAsync(IList<SimpleRequestMocker> endpointMockTemplates)
         {
-            
+
             return async (HttpRequestMessage message, CancellationToken token) =>
             {
                 var uri = message.RequestUri?.ToString();

--- a/Cognite.Simulator.Utils/Automation/AutomationUtils.cs
+++ b/Cognite.Simulator.Utils/Automation/AutomationUtils.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+
+using Microsoft.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils.Automation
 {
@@ -54,7 +55,8 @@ namespace Cognite.Simulator.Utils.Automation
             else
             {
                 var isDevelopment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT").ToLower() == "development";
-                if (!isDevelopment) {
+                if (!isDevelopment)
+                {
                     throw new SimulatorConnectionException("Simulator integration only available on Windows");
                 }
 
@@ -74,7 +76,8 @@ namespace Cognite.Simulator.Utils.Automation
             }
             finally
             {
-                if (Server != null) {
+                if (Server != null)
+                {
                     Marshal.ReleaseComObject(Server);
                     _logger.LogDebug("Released COM Object");
                     Server = null;
@@ -91,13 +94,14 @@ namespace Cognite.Simulator.Utils.Automation
 
         private dynamic ActivateAutomationServer()
         {
-            try {
+            try
+            {
                 var serverType = Type.GetTypeFromProgID(_config.ProgramId);
                 if (serverType == null)
                 {
                     _logger.LogError("Could not find automation server using the id: {ProgId}", _config.ProgramId);
                     throw new SimulatorConnectionException("Cannot connect to get automation server type");
-                }            
+                }
                 dynamic server = Activator.CreateInstance(serverType);
                 if (server == null)
                 {
@@ -106,14 +110,15 @@ namespace Cognite.Simulator.Utils.Automation
                 }
                 return server;
             }
-            catch(Exception e) {
+            catch (Exception e)
+            {
                 // wrap every exception in a SimulatorConnectionException
                 throw new SimulatorConnectionException("Cannot connect to automation server", e);
             }
 
         }
     }
-    
+
     /// <summary>
     /// Represents errors related to the connection to simulator instance
     /// </summary>
@@ -155,7 +160,7 @@ namespace Cognite.Simulator.Utils.Automation
         /// Identifier of the application/program to connect to
         /// </summary>
         public string ProgramId { get; set; }
-        
+
         /// <summary>
         /// Identifier of the process that should be terminated on shutdown, if any
         /// </summary>

--- a/Cognite.Simulator.Utils/CommonUtils.cs
+++ b/Cognite.Simulator.Utils/CommonUtils.cs
@@ -1,16 +1,19 @@
-﻿using Cognite.DataProcessing;
-using Cognite.Extractor.Common;
-using Cognite.Simulator.Extensions;
-using CogniteSdk;
-using CogniteSdk.Alpha;
-using CogniteSdk.Resources;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Cognite.DataProcessing;
+using Cognite.Extractor.Common;
+using Cognite.Simulator.Extensions;
+
+using CogniteSdk;
+using CogniteSdk.Alpha;
+using CogniteSdk.Resources;
+
 using TimeRange = CogniteSdk.TimeRange;
 
 namespace Cognite.Simulator.Utils
@@ -112,7 +115,7 @@ namespace Cognite.Simulator.Utils
                 throw new ArgumentException("Sampling window is missing", nameof(config));
             if (config.DataSampling.Granularity == null)
                 throw new ArgumentException("Granularity is missing", nameof(config));
-            
+
             var validationWindow = config.DataSampling.ValidationWindow;
             var logicalCheck = config.LogicalCheck.FirstOrDefault();
             var logicalCheckEnabled = logicalCheck != null && logicalCheck.Enabled;
@@ -150,7 +153,7 @@ namespace Cognite.Simulator.Utils
 
             // Check for steady state, if enabled
             TimeSeriesData ssdMap = null;
-            
+
             if (steadyStateDetectionEnabled)
             {
                 var ssDps = await dataPoints.GetSample(
@@ -252,7 +255,7 @@ namespace Cognite.Simulator.Utils
         public static async Task<SimulatorValueItem> LoadTimeseriesSimulationInput(
             this Client _cdf,
             SimulatorRoutineRevisionInput inputTs,
-            SimulatorRoutineRevisionConfiguration routineConfiguration, 
+            SimulatorRoutineRevisionConfiguration routineConfiguration,
             SamplingConfiguration samplingConfiguration,
             CancellationToken token)
         {
@@ -290,7 +293,7 @@ namespace Cognite.Simulator.Utils
                 var inputDps = dps.ToTimeSeriesData(
                     routineConfiguration.DataSampling.Granularity.Value,
                     inputTs.Aggregate.ToDataPointAggregate());
-                
+
                 if (inputDps.Count == 0)
                 {
                     throw new SimulationException($"Could not find data points in input timeseries {inputTs.SourceExternalId}");
@@ -299,7 +302,9 @@ namespace Cognite.Simulator.Utils
                 // This assumes the unit specified in the configuration is the same as the time series unit
                 // No unit conversion is made
                 sampledValue = inputDps.GetAverage();
-            } else {
+            }
+            else
+            {
                 var dp = await _cdf.DataPoints.GetLatestValue(inputTs.SourceExternalId, samplingConfiguration, token).ConfigureAwait(false);
                 sampledValue = dp.Value;
             }
@@ -307,7 +312,8 @@ namespace Cognite.Simulator.Utils
             return new SimulatorValueItem()
             {
                 Value = new SimulatorValue.Double(sampledValue),
-                Unit = inputTs.Unit != null ? new SimulatorValueUnit() {
+                Unit = inputTs.Unit != null ? new SimulatorValueUnit()
+                {
                     Name = inputTs.Unit.Name
                 } : null,
                 Overridden = false,

--- a/Cognite.Simulator.Utils/Configuration.cs
+++ b/Cognite.Simulator.Utils/Configuration.cs
@@ -1,18 +1,19 @@
 ﻿using System;
+
+using Cognite.Extractor.Common;
 using Cognite.Extractor.Configuration;
 using Cognite.Extractor.Logging;
 using Cognite.Extractor.Metrics;
 using Cognite.Extractor.StateStorage;
 using Cognite.Extractor.Utils;
 using Cognite.Simulator.Utils.Automation;
-using Cognite.Extractor.Common;
 
 namespace Cognite.Simulator.Utils
 {
     /// <summary>
     /// Configuration for remote logging (logs are stored in CDF)
     /// </summary>
-    public class RemoteLogConfig: LogConfig
+    public class RemoteLogConfig : LogConfig
     {
         /// <summary>
         /// Whether remote logging is enabled
@@ -23,7 +24,7 @@ namespace Cognite.Simulator.Utils
     /// <summary>
     /// Logging configuration object
     /// </summary>
-    public class LoggerConfig: Extractor.Logging.LoggerConfig
+    public class LoggerConfig : Extractor.Logging.LoggerConfig
     {
         /// <summary>
         /// Remote logging configuration (optional)
@@ -87,7 +88,8 @@ namespace Cognite.Simulator.Utils
 
             if (Logger.Remote == null)
             {
-                Logger.Remote = new RemoteLogConfig() {
+                Logger.Remote = new RemoteLogConfig()
+                {
                     Enabled = true,
                     Level = "warning"
                 };
@@ -268,7 +270,7 @@ namespace Cognite.Simulator.Utils
         public RoutineLibraryConfig RoutineLibrary { get; set; }
     }
 
-    public class DefaultConfig<TAutomationConfig> : BaseConfig 
+    public class DefaultConfig<TAutomationConfig> : BaseConfig
     where TAutomationConfig : AutomationConfig, new()
     {
         public DefaultConnectorConfig Connector { get; set; }

--- a/Cognite.Simulator.Utils/ConnectorBase.cs
+++ b/Cognite.Simulator.Utils/ConnectorBase.cs
@@ -1,17 +1,18 @@
-using Cognite.Extractor.Common;
-using Cognite.Extractor.Utils;
-using Cognite.Simulator.Extensions;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using System.Threading;
 using System.Threading.Tasks;
 
-using CogniteSdk.Alpha;
-using CogniteSdk;
+using Cognite.Extractor.Common;
+using Cognite.Extractor.Utils;
+using Cognite.Simulator.Extensions;
 using Cognite.Simulator.Utils.Automation;
+
+using CogniteSdk;
+using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils
 {
@@ -34,7 +35,7 @@ namespace Cognite.Simulator.Utils
     /// <summary>
     /// License status
     /// </summary>
-    public enum LicenseStatus 
+    public enum LicenseStatus
     {
         /// <summary>
         /// License is available.
@@ -63,7 +64,7 @@ namespace Cognite.Simulator.Utils
         /// CDF client wrapper
         /// </summary>
         protected CogniteDestination Cdf { get; }
-        
+
         /// <summary>
         /// Simulator definition, containing the simulator name, supported units, etc.
         /// </summary>
@@ -116,7 +117,7 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         /// <param name="token">Cancellation token</param>
         public abstract Task Init(CancellationToken token);
-        
+
         /// <summary>
         /// Implements the connector loop. Should call the <see cref="HeartbeatLoop(CancellationToken)"/> method and any
         /// other thats that are done periodically by the connector
@@ -166,7 +167,7 @@ namespace Cognite.Simulator.Utils
             int interval = _config.LicenseCheck.Interval < ONE_HOUR ? ONE_HOUR : _config.LicenseCheck.Interval;
             return TimeSpan.FromSeconds(interval);
         }
-        
+
         /// <summary>
         /// If the connector should check and report the license status back to CDF
         /// </summary>
@@ -192,7 +193,7 @@ namespace Cognite.Simulator.Utils
                 var integrations = integrationRes.Items;
                 var connectorName = GetConnectorName();
                 var simulatorExternalId = SimulatorDefinition.ExternalId;
-                    
+
                 var existing = integrations.FirstOrDefault(i => i.ExternalId == connectorName && i.SimulatorExternalId == simulatorExternalId);
                 if (existing == null)
                 {
@@ -232,7 +233,7 @@ namespace Cognite.Simulator.Utils
         protected async Task UpdateRemoteSimulatorIntegration(
             bool init,
             CancellationToken token)
-        {   
+        {
             if (init)
             {
                 LastLicenseCheckResult = ShouldLicenseCheck() ? LicenseStatus.UNKNOWN : LicenseStatus.DISABLED;
@@ -250,8 +251,9 @@ namespace Cognite.Simulator.Utils
                     ConnectorStatusUpdatedTime = new Update<long> { Set = DateTime.UtcNow.ToUnixTimeMilliseconds() },
                     Heartbeat = new Update<long> { Set = DateTime.UtcNow.ToUnixTimeMilliseconds() },
                     LicenseLastCheckedTime = new Update<long> { Set = LastLicenseCheckTimestamp },
-                    LicenseStatus = new Update<string> { Set = LastLicenseCheckResult.ToString() }, 
-                } : new SimulatorIntegrationUpdate {
+                    LicenseStatus = new Update<string> { Set = LastLicenseCheckResult.ToString() },
+                } : new SimulatorIntegrationUpdate
+                {
                     Heartbeat = new Update<long> { Set = DateTime.UtcNow.ToUnixTimeMilliseconds() },
                     LicenseLastCheckedTime = new Update<long> { Set = LastLicenseCheckTimestamp },
                     LicenseStatus = new Update<string> { Set = LastLicenseCheckResult.ToString() },
@@ -262,11 +264,11 @@ namespace Cognite.Simulator.Utils
                     throw new ConnectorException($"Simulator integration for {simulatorExternalId} not found");
                 }
                 var integrationUpdateItem = new UpdateItem<SimulatorIntegrationUpdate>(RemoteSimulatorIntegration.Id)
-                    {
-                        Update = integrationUpdate,
-                    };
+                {
+                    Update = integrationUpdate,
+                };
                 await simulatorsApi.UpdateSimulatorIntegrationAsync(
-                    new [] { integrationUpdateItem },
+                    new[] { integrationUpdateItem },
                     token).ConfigureAwait(false);
             }
             catch (CogniteException e)
@@ -301,7 +303,7 @@ namespace Cognite.Simulator.Utils
         /// <returns>True if the simulator has a valid license, false otherwise.</returns>
         public LicenseStatus GetLicenseStatus()
         {
-            return  LicenseStatus.AVAILABLE;
+            return LicenseStatus.AVAILABLE;
         }
         /// <summary>
         /// Task that runs in a loop, reporting the connector license status to CDF periodically
@@ -318,12 +320,12 @@ namespace Cognite.Simulator.Utils
                     .ConfigureAwait(false);
                 _logger.LogDebug("Updating connector license timestamp");
                 LastLicenseCheckTimestamp = DateTime.UtcNow.ToUnixTimeMilliseconds();
-                LastLicenseCheckResult = GetLicenseStatus() ;
+                LastLicenseCheckResult = GetLicenseStatus();
                 await UpdateRemoteSimulatorIntegration(false, token)
                     .ConfigureAwait(false);
             }
         }
-        
+
         /// <summary>
         /// Task that runs in a loop, checking for new config in extraction pipelines
         /// </summary>
@@ -351,7 +353,7 @@ namespace Cognite.Simulator.Utils
     public class NewConfigDetected : Exception
     {
     }
-    
+
     /// <summary>
     /// Represents errors related to the connector operation
     /// </summary>

--- a/Cognite.Simulator.Utils/DefaultClasses/DefaultConnector.cs
+++ b/Cognite.Simulator.Utils/DefaultClasses/DefaultConnector.cs
@@ -5,24 +5,27 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Cognite.Extractor.Utils;
 using Cognite.Simulator.Utils.Automation;
+
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils
 {
-    public class DefaultConnector<TAutomationConfig,TModelState,TModelStateBasePoco> : ConnectorBase<DefaultConfig<TAutomationConfig>>  
+    public class DefaultConnector<TAutomationConfig, TModelState, TModelStateBasePoco> : ConnectorBase<DefaultConfig<TAutomationConfig>>
         where TAutomationConfig : AutomationConfig, new()
-         where TModelState: ModelStateBase, new()
-         where TModelStateBasePoco: ModelStateBasePoco
- 
+         where TModelState : ModelStateBase, new()
+         where TModelStateBasePoco : ModelStateBasePoco
+
     {
         private readonly DefaultConfig<TAutomationConfig> _config;
-        private readonly ILogger<DefaultConnector<TAutomationConfig,TModelState,TModelStateBasePoco>> _logger;
-        private readonly DefaultModelLibrary<TAutomationConfig,TModelState,TModelStateBasePoco> _modelLibrary;
+        private readonly ILogger<DefaultConnector<TAutomationConfig, TModelState, TModelStateBasePoco>> _logger;
+        private readonly DefaultModelLibrary<TAutomationConfig, TModelState, TModelStateBasePoco> _modelLibrary;
         private readonly DefaultRoutineLibrary<TAutomationConfig> _routineLibrary;
-        private readonly DefaultSimulationRunner<TAutomationConfig,TModelState,TModelStateBasePoco> _simulationRunner;
+        private readonly DefaultSimulationRunner<TAutomationConfig, TModelState, TModelStateBasePoco> _simulationRunner;
         private readonly DefaultSimulationScheduler<TAutomationConfig> _scheduler;
         private readonly ExtractionPipeline _pipeline;
         private readonly string _version;
@@ -33,13 +36,13 @@ namespace Cognite.Simulator.Utils
         public DefaultConnector(
             CogniteDestination cdf,
             DefaultConfig<TAutomationConfig> config,
-            DefaultModelLibrary<TAutomationConfig,TModelState,TModelStateBasePoco> modelLibrary,
+            DefaultModelLibrary<TAutomationConfig, TModelState, TModelStateBasePoco> modelLibrary,
             DefaultRoutineLibrary<TAutomationConfig> routineLibrary,
-            DefaultSimulationRunner<TAutomationConfig,TModelState,TModelStateBasePoco> runner,
+            DefaultSimulationRunner<TAutomationConfig, TModelState, TModelStateBasePoco> runner,
             DefaultSimulationScheduler<TAutomationConfig> scheduler,
             ExtractionPipeline pipeline,
             SimulatorCreate simulatorDefinition,
-            ILogger<DefaultConnector<TAutomationConfig,TModelState,TModelStateBasePoco>> logger,
+            ILogger<DefaultConnector<TAutomationConfig, TModelState, TModelStateBasePoco>> logger,
             RemoteConfigManager<DefaultConfig<TAutomationConfig>> remoteConfigManager,
             ISimulatorClient<TModelState, SimulatorRoutineRevision> simulatorClient,
             ScopedRemoteApiSink sink)
@@ -55,7 +58,7 @@ namespace Cognite.Simulator.Utils
             _pipeline = pipeline;
             _simulatorClient = simulatorClient;
 
-        
+
             _version = Extractor.Metrics.Version.GetVersion(
                     Assembly.GetExecutingAssembly(),
                     "0.0.1");
@@ -76,7 +79,8 @@ namespace Cognite.Simulator.Utils
             await _simulatorClient.TestConnection(token).ConfigureAwait(false);
             await _pipeline.Init(_config.Connector, token).ConfigureAwait(false);
             await InitRemoteSimulatorIntegration(token).ConfigureAwait(false);
-            if(RemoteSimulatorIntegration != null){
+            if (RemoteSimulatorIntegration != null)
+            {
                 _sink.SetDefaultLogId(RemoteSimulatorIntegration.LogId);
             }
             await UpdateRemoteSimulatorIntegration(true, token).ConfigureAwait(false);
@@ -84,7 +88,8 @@ namespace Cognite.Simulator.Utils
             await _routineLibrary.Init(token).ConfigureAwait(false);
         }
 
-        private Task RunAllTasks(CancellationTokenSource linkedTokenSource) {
+        private Task RunAllTasks(CancellationTokenSource linkedTokenSource)
+        {
             var linkedToken = linkedTokenSource.Token;
             var modelLibTasks = _modelLibrary.GetRunTasks(linkedToken);
             var routineLibTasks = _routineLibrary.GetRunTasks(linkedToken);
@@ -105,7 +110,7 @@ namespace Cognite.Simulator.Utils
         {
             _logger.LogInformation("Connector started, sending status to CDF every {Interval} seconds",
                 _config.Connector.StatusInterval);
-                
+
             try
             {
                 using (var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token))
@@ -135,6 +140,6 @@ namespace Cognite.Simulator.Utils
                 _logger.LogError(ex, "An error occurred during task execution");
                 throw;
             }
-        }   
+        }
     }
 }

--- a/Cognite.Simulator.Utils/DefaultClasses/DefaultConnectorRuntime.cs
+++ b/Cognite.Simulator.Utils/DefaultClasses/DefaultConnectorRuntime.cs
@@ -6,15 +6,19 @@ using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Cognite.Extractor.Common;
 using Cognite.Extractor.StateStorage;
 using Cognite.Extractor.Utils;
 using Cognite.Simulator.Utils;
 using Cognite.Simulator.Utils.Automation;
+
 using CogniteSdk;
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+
 using Polly.Timeout;
 
 /// <summary>
@@ -23,8 +27,8 @@ using Polly.Timeout;
 /// </summary>
 public class DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelStateBasePoco>
  where TAutomationConfig : AutomationConfig, new()
- where TModelState: ModelStateBase, new()
- where TModelStateBasePoco: ModelStateBasePoco
+ where TModelState : ModelStateBase, new()
+ where TModelStateBasePoco : ModelStateBasePoco
 {
     /// <summary>
     /// Delegate to configure services. This will be called before the services are built.
@@ -85,25 +89,29 @@ public class DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelState
     /// <param name="logger"></param>
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
-    public static SimulatorUpdateItem PrepareUpdateSimulatorObject(Simulator existingSimulatorDefinition, 
-    SimulatorCreate newSimulatorDefinition, ILogger<DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelStateBasePoco>> logger )
+    public static SimulatorUpdateItem PrepareUpdateSimulatorObject(Simulator existingSimulatorDefinition,
+    SimulatorCreate newSimulatorDefinition, ILogger<DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelStateBasePoco>> logger)
     {
-        if (existingSimulatorDefinition == null) {
+        if (existingSimulatorDefinition == null)
+        {
             throw new Exception("Simulator definition from remote is null");
         }
 
-        if (newSimulatorDefinition == null) {
+        if (newSimulatorDefinition == null)
+        {
             throw new Exception("New simulator definition is null");
         }
 
-        var update = new SimulatorUpdate {
+        var update = new SimulatorUpdate
+        {
             FileExtensionTypes = new Update<IEnumerable<string>> { Set = newSimulatorDefinition.FileExtensionTypes },
             ModelTypes = new Update<IEnumerable<SimulatorModelType>> { Set = newSimulatorDefinition.ModelTypes },
             StepFields = new Update<IEnumerable<SimulatorStepField>> { Set = newSimulatorDefinition.StepFields },
         };
 
         // Optional fields
-        if (newSimulatorDefinition.UnitQuantities != null) {
+        if (newSimulatorDefinition.UnitQuantities != null)
+        {
             update.UnitQuantities = new Update<IEnumerable<SimulatorUnitQuantity>> { Set = newSimulatorDefinition.UnitQuantities };
         }
 
@@ -111,26 +119,32 @@ public class DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelState
         return new SimulatorUpdateItem(existingSimulatorDefinition.Id) { Update = update };
     }
 
-    private static async Task GetOrCreateSimulator( Client cdfClient, DefaultConfig<TAutomationConfig> config, 
-    ILogger<DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelStateBasePoco>> logger, CancellationToken token) {
+    private static async Task GetOrCreateSimulator(Client cdfClient, DefaultConfig<TAutomationConfig> config,
+    ILogger<DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelStateBasePoco>> logger, CancellationToken token)
+    {
         var definition = SimulatorDefinition;
         var existingSimulators = await cdfClient.Alpha.Simulators.ListAsync(new SimulatorQuery(), token).ConfigureAwait(false);
         var existingSimulator = existingSimulators.Items.FirstOrDefault(s => s.ExternalId == definition.ExternalId);
-        if (definition == null && existingSimulator == null) {
+        if (definition == null && existingSimulator == null)
+        {
             throw new Exception("Simulator definition not found in either the remote API or locally.");
         }
-        if (definition != null) {
+        if (definition != null)
+        {
             logger.LogDebug("Simulator definition found locally");
-            if (existingSimulator == null) {
+            if (existingSimulator == null)
+            {
                 logger.LogDebug("Simulator definition not found on CDF, will create one remotely");
                 var res = await cdfClient.Alpha.Simulators.CreateAsync(new List<SimulatorCreate> { definition }, token).ConfigureAwait(false);
-            } else {
+            }
+            else
+            {
                 var updateItem = PrepareUpdateSimulatorObject(existingSimulator, definition, logger);
                 logger.LogDebug("Updating simulator definition");
                 var simulatorsToUpdate = new List<SimulatorUpdateItem> { updateItem };
-                await cdfClient.Alpha.Simulators.UpdateAsync(simulatorsToUpdate, token).ConfigureAwait(false);                
+                await cdfClient.Alpha.Simulators.UpdateAsync(simulatorsToUpdate, token).ConfigureAwait(false);
             }
-        } 
+        }
     }
 
     public static async Task Run(ILogger defaultLogger, CancellationToken token)
@@ -159,10 +173,10 @@ public class DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelState
         services.AddHttpClient<FileStorageClient>();
         services.AddScoped<TAutomationConfig>();
         services.AddSingleton(SimulatorDefinition);
-        services.AddScoped<DefaultConnector<TAutomationConfig,TModelState,TModelStateBasePoco>>();
-        services.AddScoped<DefaultModelLibrary<TAutomationConfig,TModelState,TModelStateBasePoco>>();
+        services.AddScoped<DefaultConnector<TAutomationConfig, TModelState, TModelStateBasePoco>>();
+        services.AddScoped<DefaultModelLibrary<TAutomationConfig, TModelState, TModelStateBasePoco>>();
         services.AddScoped<DefaultRoutineLibrary<TAutomationConfig>>();
-        services.AddScoped<DefaultSimulationRunner<TAutomationConfig,TModelState,TModelStateBasePoco>>();
+        services.AddScoped<DefaultSimulationRunner<TAutomationConfig, TModelState, TModelStateBasePoco>>();
         services.AddScoped<DefaultSimulationScheduler<TAutomationConfig>>();
 
         defaultLogger.LogDebug("Injecting services");
@@ -176,7 +190,7 @@ public class DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelState
         var provider = services.BuildServiceProvider();
 
 
-        var logger = provider.GetRequiredService<ILogger<DefaultConnectorRuntime<TAutomationConfig,TModelState,TModelStateBasePoco>>>();
+        var logger = provider.GetRequiredService<ILogger<DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelStateBasePoco>>>();
 
         logger.LogInformation("Starting the connector...");
 
@@ -195,13 +209,13 @@ public class DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelState
             using (var scope = provider.CreateScope())
             {
                 var pipeline = scope.ServiceProvider.GetRequiredService<ExtractionPipeline>();
-                
+
                 try
                 {
-                    var connector = scope.ServiceProvider.GetRequiredService<DefaultConnector<TAutomationConfig,TModelState,TModelStateBasePoco>>();
+                    var connector = scope.ServiceProvider.GetRequiredService<DefaultConnector<TAutomationConfig, TModelState, TModelStateBasePoco>>();
 
                     await connector.Init(token).ConfigureAwait(false);
-                   
+
                     await connector.Run(token).ConfigureAwait(false);
                 }
                 catch (TaskCanceledException) when (token.IsCancellationRequested)
@@ -265,7 +279,7 @@ public class DefaultConnectorRuntime<TAutomationConfig, TModelState, TModelState
                 }
             }
         }
-        
+
         logger.LogInformation("Connector exiting");
 
     }

--- a/Cognite.Simulator.Utils/DefaultClasses/DefaultModelLibrary.cs
+++ b/Cognite.Simulator.Utils/DefaultClasses/DefaultModelLibrary.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Cognite.Extractor.StateStorage;
 using Cognite.Extractor.Utils;
 using Cognite.Simulator.Utils.Automation;
+
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -19,9 +22,9 @@ namespace Cognite.Simulator.Utils
     /// <typeparam name="TModelStateBase">Type of the model state</typeparam>
     /// <typeparam name="TModelStateBasePoco">Type of the model state POCO</typeparam>
     public class DefaultModelLibrary<TAutomationConfig, TModelStateBase, TModelStateBasePoco> :
-    ModelLibraryBase<TAutomationConfig,TModelStateBase, TModelStateBasePoco, ModelParsingInfo>
+    ModelLibraryBase<TAutomationConfig, TModelStateBase, TModelStateBasePoco, ModelParsingInfo>
     where TAutomationConfig : AutomationConfig, new()
-    where TModelStateBase: ModelStateBase, new()
+    where TModelStateBase : ModelStateBase, new()
     where TModelStateBasePoco : ModelStateBasePoco
     {
         private ISimulatorClient<TModelStateBase, SimulatorRoutineRevision> simulatorClient;
@@ -32,7 +35,7 @@ namespace Cognite.Simulator.Utils
         public DefaultModelLibrary(
             DefaultConfig<TAutomationConfig> config,
             CogniteDestination cdf,
-            ILogger<DefaultModelLibrary<TAutomationConfig,TModelStateBase,TModelStateBasePoco>> logger,
+            ILogger<DefaultModelLibrary<TAutomationConfig, TModelStateBase, TModelStateBasePoco>> logger,
             ISimulatorClient<TModelStateBase, SimulatorRoutineRevision> simulatorClient,
             SimulatorCreate simulatorDefinition,
             FileStorageClient client,
@@ -51,10 +54,14 @@ namespace Cognite.Simulator.Utils
         protected override async Task ExtractModelInformation(
             TModelStateBase state,
             CancellationToken token
-        ) {
-            if (simulatorClient != null) {
+        )
+        {
+            if (simulatorClient != null)
+            {
                 await simulatorClient.ExtractModelInformation(state, token).ConfigureAwait(false);
-            } else {
+            }
+            else
+            {
                 state.CanRead = true;
                 state.ParsingInfo.SetSuccess();
             }

--- a/Cognite.Simulator.Utils/DefaultClasses/DefaultModelState.cs
+++ b/Cognite.Simulator.Utils/DefaultClasses/DefaultModelState.cs
@@ -1,15 +1,18 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Cognite.Extractor.StateStorage;
 using Cognite.Extractor.Utils;
+
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils
 {
 
-   public class DefaultModelFileStatePoco : ModelStateBasePoco
+    public class DefaultModelFileStatePoco : ModelStateBasePoco
     {
         [StateStoreProperty("info-extracted")]
         public bool InformationExtracted { get; internal set; }

--- a/Cognite.Simulator.Utils/DefaultClasses/DefaultSimulationRunner.cs
+++ b/Cognite.Simulator.Utils/DefaultClasses/DefaultSimulationRunner.cs
@@ -1,39 +1,36 @@
 using System.Collections.Generic;
 
-
-using Microsoft.Extensions.Logging;
-
 using Cognite.Extractor.Utils;
-
-using CogniteSdk.Alpha;
-
-
 using Cognite.Simulator.Extensions;
 using Cognite.Simulator.Utils.Automation;
 
+using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.Logging;
+
 namespace Cognite.Simulator.Utils
 {
-    public class DefaultSimulationRunner<TAutomationConfig,TModelStateBase,TModelStateBasePoco> : 
-        RoutineRunnerBase<TAutomationConfig,TModelStateBase, SimulatorRoutineRevision>
+    public class DefaultSimulationRunner<TAutomationConfig, TModelStateBase, TModelStateBasePoco> :
+        RoutineRunnerBase<TAutomationConfig, TModelStateBase, SimulatorRoutineRevision>
          where TAutomationConfig : AutomationConfig, new()
-         where TModelStateBase: ModelStateBase, new()
-         where TModelStateBasePoco: ModelStateBasePoco
+         where TModelStateBase : ModelStateBase, new()
+         where TModelStateBasePoco : ModelStateBasePoco
     {
 
         public DefaultSimulationRunner(
             DefaultConfig<TAutomationConfig> config,
-            CogniteDestination cdf, 
-            DefaultModelLibrary<TAutomationConfig, TModelStateBase,TModelStateBasePoco> modelLibrary, 
+            CogniteDestination cdf,
+            DefaultModelLibrary<TAutomationConfig, TModelStateBase, TModelStateBasePoco> modelLibrary,
             DefaultRoutineLibrary<TAutomationConfig> configLibrary,
             SimulatorCreate simulatorDefinition,
             ISimulatorClient<TModelStateBase, SimulatorRoutineRevision> client,
-            ILogger<DefaultSimulationRunner<TAutomationConfig,TModelStateBase,TModelStateBasePoco>> logger) : 
+            ILogger<DefaultSimulationRunner<TAutomationConfig, TModelStateBase, TModelStateBasePoco>> logger) :
             base(config.Connector,
-                simulatorDefinition, 
-                cdf, 
-                modelLibrary, 
-                configLibrary, 
-                client, 
+                simulatorDefinition,
+                cdf,
+                modelLibrary,
+                configLibrary,
+                client,
                 logger
             )
         {

--- a/Cognite.Simulator.Utils/ExtractionPipeline.cs
+++ b/Cognite.Simulator.Utils/ExtractionPipeline.cs
@@ -1,14 +1,17 @@
-﻿using Cognite.Extensions;
-using Cognite.Extractor.Utils;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Cognite.Extensions;
 using Cognite.Extractor.Configuration;
+using Cognite.Extractor.Utils;
+
 using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils
 {
@@ -25,7 +28,7 @@ namespace Cognite.Simulator.Utils
         private ConnectorConfig _connectorConfig;
         private CogniteSdk.ExtPipe _pipeline;
         private bool _disabled;
-        
+
         internal static string LastErrorMessage;
 
         /// <summary>
@@ -51,7 +54,7 @@ namespace Cognite.Simulator.Utils
             _cdfConfig = cdfConfig;
             _pipeConfig = pipeConfig;
         }
-        
+
         /// <summary>
         /// Initialized the extraction pipeline, if configured. This method creates a new
         /// pipeline in CDF in case one does not exists. It uses the simulator name and 
@@ -81,18 +84,19 @@ namespace Cognite.Simulator.Utils
         /// Try to initialize the extraction pipeline by creating it in CDF (if it does not exist)
         /// </summary>
         /// <param name="token">Cancellation token</param>
-        private async Task<bool> TryInitRemotePipeline(CancellationToken token) {
+        private async Task<bool> TryInitRemotePipeline(CancellationToken token)
+        {
             try
             {
                 var pipelineId = _cdfConfig.ExtractionPipeline.PipelineId;
                 var pipelines = await _cdf.CogniteClient.ExtPipes.RetrieveAsync(
-                    [ pipelineId ], 
-                    true, 
+                    [pipelineId],
+                    true,
                     token).ConfigureAwait(false);
                 if (!pipelines.Any())
                 {
                     _logger.LogWarning(
-                        "Could not find an extraction pipeline with id {Id}, attempting to create one", 
+                        "Could not find an extraction pipeline with id {Id}, attempting to create one",
                         pipelineId);
                     pipelines = await _cdf.CogniteClient.ExtPipes.CreateAsync(
                         new List<CogniteSdk.ExtPipeCreate>
@@ -145,7 +149,7 @@ namespace Cognite.Simulator.Utils
             }
 
             _logger.LogDebug("Notifying extraction pipeline, status: {Status}", status);
-            
+
             try
             {
                 await _cdf.CogniteClient.ExtPipes.CreateRunsAsync(
@@ -175,19 +179,19 @@ namespace Cognite.Simulator.Utils
                 $"Connector restarted after error: {LastErrorMessage}" :
                 "Connector started";
             await NotifyPipeline(
-                CogniteSdk.ExtPipeRunStatus.success, 
-                startMessage, 
+                CogniteSdk.ExtPipeRunStatus.success,
+                startMessage,
                 token).ConfigureAwait(false);
 
             var delay = _cdfConfig.ExtractionPipeline.Frequency;
             while (!token.IsCancellationRequested)
             {
                 await NotifyPipeline(
-                   CogniteSdk.ExtPipeRunStatus.seen, 
-                   "Connector available", 
+                   CogniteSdk.ExtPipeRunStatus.seen,
+                   "Connector available",
                    token).ConfigureAwait(false);
                 await Task.Delay(
-                    TimeSpan.FromSeconds(delay), 
+                    TimeSpan.FromSeconds(delay),
                     token).ConfigureAwait(false);
             }
         }
@@ -254,7 +258,7 @@ namespace Cognite.Simulator.Utils
             services.AddSingleton(config.PipelineNotification);
             services.AddScoped<ExtractionPipeline>();
         }
-        
+
         /// <summary>
         /// Use `type: remote` to fetch the config from Fusion, or use `type: local` to use the local file instead
         /// Example from config.yml using the remote config from Fusion
@@ -284,7 +288,7 @@ namespace Cognite.Simulator.Utils
             int version = 1,
             int[] acceptedConfigVersions = null) where T : BaseConfig
         {
-            var configTypes = new [] {
+            var configTypes = new[] {
                 typeof(CogniteConfig),
                 typeof(LoggerConfig),
                 typeof(HighAvailabilityConfig),
@@ -292,14 +296,14 @@ namespace Cognite.Simulator.Utils
                 typeof(Extractor.StateStorage.StateStoreConfig),
                 typeof(BaseConfig)
             };
-            var localConfig = services.AddConfig<T>(path, configTypes, new [] { version });
+            var localConfig = services.AddConfig<T>(path, configTypes, new[] { version });
 
             var remoteConfig = new RemoteConfig
             {
                 Type = localConfig.Type,
                 Cognite = localConfig.Cognite
             };
-            
+
             return await services.AddRemoteConfig<T>(
                 logger: null,
                 path: path,

--- a/Cognite.Simulator.Utils/FileState.cs
+++ b/Cognite.Simulator.Utils/FileState.cs
@@ -1,8 +1,9 @@
-﻿using Cognite.Extractor.StateStorage;
-using Cognite.Simulator.Extensions;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+using Cognite.Extractor.StateStorage;
+using Cognite.Simulator.Extensions;
 
 namespace Cognite.Simulator.Utils
 {
@@ -16,7 +17,7 @@ namespace Cognite.Simulator.Utils
         /// File id. Typically CDF external id
         /// </summary>
         public string Id { get; set; }
-        
+
         private string _externalId;
         /// <summary>
         /// External ID of the entity that is represented by this object.
@@ -46,7 +47,7 @@ namespace Cognite.Simulator.Utils
         }
 
         private string _modelExternalId;
-        
+
         /// <summary>
         /// External ID of the model associated with this file. The model is
         /// typically the object being simulated.
@@ -70,7 +71,8 @@ namespace Cognite.Simulator.Utils
         /// <summary>
         /// If the file is stored in a directory, or as a single file
         /// </summary>
-        public bool IsInDirectory {
+        public bool IsInDirectory
+        {
             get => _isInDirectory;
             set
             {
@@ -95,7 +97,7 @@ namespace Cognite.Simulator.Utils
         }
 
         private long? _dataSetId;
-        
+
         /// <summary>
         /// Dataset id that contains the file in CDF
         /// </summary>
@@ -111,7 +113,7 @@ namespace Cognite.Simulator.Utils
         }
 
         private string _filePath;
-        
+
         /// <summary>
         /// Path of the file in the local disk. This is only available
         /// once the file has been downloaded from CDF and saved locally.
@@ -128,7 +130,7 @@ namespace Cognite.Simulator.Utils
         }
 
         private long _createdTime;
-        
+
         /// <summary>
         /// Time the file was created in CDF
         /// </summary>
@@ -144,7 +146,7 @@ namespace Cognite.Simulator.Utils
         }
 
         private long _updatedTime;
-        
+
         /// <summary>
         /// Last time the file was updated in CDF
         /// </summary>
@@ -160,7 +162,7 @@ namespace Cognite.Simulator.Utils
         }
 
         private long _cdfId;
-        
+
         /// <summary>
         /// Internal (numeric) id of the file in CDF
         /// </summary>
@@ -179,7 +181,8 @@ namespace Cognite.Simulator.Utils
         /// <summary>
         /// Model revision logId
         /// </summary>
-        public long LogId {
+        public long LogId
+        {
             get => _logId;
             set
             {
@@ -227,7 +230,8 @@ namespace Cognite.Simulator.Utils
         /// <summary>
         /// Download attempts
         /// </summary>
-        public int DownloadAttempts {
+        public int DownloadAttempts
+        {
             get => _downloadAttempts;
             set
             {
@@ -287,7 +291,7 @@ namespace Cognite.Simulator.Utils
             };
         }
     }
-    
+
     /// <summary>
     /// Data object that contains the state properties to be persisted
     /// by the state store. These properties are restored to the state on initialization
@@ -317,37 +321,37 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         [StateStoreProperty("model-external-id")]
         public string ModelExternalId { get; set; }
-        
+
         /// <summary>
         /// Source of the file (simulator)
         /// </summary>
         [StateStoreProperty("source")]
         public string Source { get; set; }
-        
+
         /// <summary>
         /// Dataset id in CDF
         /// </summary>
         [StateStoreProperty("data-set-id")]
         public long? DataSetId { get; set; }
-        
+
         /// <summary>
         /// Path to the file in the local disk
         /// </summary>
         [StateStoreProperty("file-path")]
         public string FilePath { get; set; }
-        
+
         /// <summary>
         /// Time the file was created in CDF
         /// </summary>
         [StateStoreProperty("created-time")]
         public long CreatedTime { get; set; }
-        
+
         /// <summary>
         /// CDF internal id of the file 
         /// </summary>
         [StateStoreProperty("cdf-id")]
         public long CdfId { get; set; }
-        
+
         /// <summary>
         /// Last time the file was updated in CDF
         /// </summary>

--- a/Cognite.Simulator.Utils/FileStorageClient.cs
+++ b/Cognite.Simulator.Utils/FileStorageClient.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils
 {
@@ -116,8 +117,10 @@ namespace Cognite.Simulator.Utils
         /// <param name="fileStream"></param>
         /// <returns></returns>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task UploadFileAsync(Uri uri, StreamContent fileStream) {
-            if (fileStream == null) {
+        public async Task UploadFileAsync(Uri uri, StreamContent fileStream)
+        {
+            if (fileStream == null)
+            {
                 throw new ArgumentNullException(nameof(fileStream));
             }
 
@@ -126,7 +129,8 @@ namespace Cognite.Simulator.Utils
             var putResponse = await _client.PutAsync(uri, fileStream).ConfigureAwait(false);
 
             putResponse.EnsureSuccessStatusCode();
-            if (putResponse.StatusCode >= System.Net.HttpStatusCode.BadRequest) {
+            if (putResponse.StatusCode >= System.Net.HttpStatusCode.BadRequest)
+            {
                 throw new HttpRequestException(
                     $"Did not get a success HTTP response on file upload: {putResponse.StatusCode} url: {uri}"
                 );

--- a/Cognite.Simulator.Utils/Logger.cs
+++ b/Cognite.Simulator.Utils/Logger.cs
@@ -3,17 +3,19 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Cognite.Extractor.Logging;
+
+using CogniteSdk;
+using CogniteSdk.Resources.Alpha;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+
 using Serilog;
-using Serilog.Extensions.Logging;
 using Serilog.Core;
 using Serilog.Core.Enrichers;
 using Serilog.Events;
-
-using CogniteSdk;
-using Cognite.Extractor.Logging;
-using CogniteSdk.Resources.Alpha;
+using Serilog.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils
 {
@@ -41,14 +43,17 @@ namespace Cognite.Simulator.Utils
 
             if (checkForSeverityOverride && logId.HasValue)
             {
-                try {
+                try
+                {
                     var logRes = await cdf.RetrieveSimulatorLogsAsync([new Identity(logId.Value)]).ConfigureAwait(false);
                     var logItem = logRes.First();
                     if (logItem.Severity != null)
                     {
                         enrichers.Add(new PropertyEnricher("Severity", logItem.Severity));
                     }
-                } catch (Exception) {
+                }
+                catch (Exception)
+                {
                     // Ignore, we don't want to fail everything if we can't get the log item
                 }
             }
@@ -58,8 +63,10 @@ namespace Cognite.Simulator.Utils
 
         // Enricher that creates a property with UTC timestamp.
         // See: https://github.com/serilog/serilog/issues/1024#issuecomment-338518695
-        class UtcTimestampEnricher : ILogEventEnricher {
-            public void Enrich(LogEvent logEvent, ILogEventPropertyFactory lepf) {
+        class UtcTimestampEnricher : ILogEventEnricher
+        {
+            public void Enrich(LogEvent logEvent, ILogEventPropertyFactory lepf)
+            {
                 logEvent.AddPropertyIfAbsent(
                     lepf.CreateProperty("UtcTimestamp", logEvent.Timestamp.UtcDateTime));
             }
@@ -69,7 +76,8 @@ namespace Cognite.Simulator.Utils
         /// Create a default Serilog console logger and returns it.
         /// </summary>
         /// <returns>A <see cref="Serilog.ILogger"/> logger with default properties</returns>
-        public static Serilog.ILogger GetSerilogDefault() {
+        public static Serilog.ILogger GetSerilogDefault()
+        {
             return new LoggerConfiguration()
                 .Enrich.With<UtcTimestampEnricher>()
                 .Enrich.FromLogContext()
@@ -96,7 +104,8 @@ namespace Cognite.Simulator.Utils
         /// Create a default console logger and returns it.
         /// </summary>
         /// <returns>A <see cref="Microsoft.Extensions.Logging.ILogger"/> logger with default properties</returns>
-        public static Microsoft.Extensions.Logging.ILogger GetDefault() {
+        public static Microsoft.Extensions.Logging.ILogger GetDefault()
+        {
             using (var loggerFactory = new LoggerFactory())
             {
                 loggerFactory.AddSerilog(GetSerilogDefault(), true);
@@ -119,11 +128,12 @@ namespace Cognite.Simulator.Utils
         }
 
     }
-   
+
     /// <summary>
     /// Extension utilities for logging
     /// </summary>
-    public static class LoggingExtensions {
+    public static class LoggingExtensions
+    {
 
 
 
@@ -140,7 +150,7 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         /// <param name="services">The service collection</param>
         /// <param name="alternativeLogger">True to allow alternative loggers, i.e. allow config.Console and config.File to be null</param>
-        public static void AddLogger(this IServiceCollection services,  bool alternativeLogger = false) 
+        public static void AddLogger(this IServiceCollection services, bool alternativeLogger = false)
         {
             services.AddSingleton<ScopedRemoteApiSink>();
             services.AddSingleton<LoggerTraceListener>();

--- a/Cognite.Simulator.Utils/ModelParsingInfo.cs
+++ b/Cognite.Simulator.Utils/ModelParsingInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+
 using CogniteSdk.Alpha;
 
 namespace Cognite.Simulator.Utils
@@ -21,12 +22,12 @@ namespace Cognite.Simulator.Utils
         /// Status message
         /// </summary>
         public string StatusMessage { get; set; }
-        
+
         /// <summary>
         /// Whether or not the model was parsed
         /// </summary>
         public bool Parsed { get; set; }
-        
+
         /// <summary>
         /// If there were any errors during parsing
         /// </summary>
@@ -44,7 +45,7 @@ namespace Cognite.Simulator.Utils
         /// Update the model info status to failure
         /// </summary>
         /// <param name="statusMessage">Status message</param>
-        public void SetFailure( string statusMessage = "Model parsing failed")
+        public void SetFailure(string statusMessage = "Model parsing failed")
         {
             this.SetStatus(SimulatorModelRevisionStatus.failure, true, true, statusMessage);
         }

--- a/Cognite.Simulator.Utils/ModelStateBase.cs
+++ b/Cognite.Simulator.Utils/ModelStateBase.cs
@@ -1,7 +1,7 @@
 using System;
 
-using Cognite.Simulator.Extensions;
 using Cognite.Extractor.StateStorage;
+using Cognite.Simulator.Extensions;
 
 
 namespace Cognite.Simulator.Utils
@@ -23,7 +23,7 @@ namespace Cognite.Simulator.Utils
         /// Indicates if information has been extracted from the model file
         /// </summary>
         public abstract bool IsExtracted { get; }
-        
+
         /// <summary>
         /// Indicates if the simulator can read the model file and
         /// its data

--- a/Cognite.Simulator.Utils/ProcessUtils.cs
+++ b/Cognite.Simulator.Utils/ProcessUtils.cs
@@ -1,22 +1,25 @@
-using System.Linq;
 using System;
-using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 using System.Collections.Generic;
-using System.Runtime.Versioning;
-using Cognite.Simulator.Utils.Automation;
-using Cognite.Simulator.Utils;
-using System.Threading;
+using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Management;
-using System.Security.Principal;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Security.Principal;
+using System.Threading;
 using System.Threading.Tasks;
+
+using Cognite.Simulator.Utils;
+using Cognite.Simulator.Utils.Automation;
+
+using Microsoft.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils
 {
-     public static class ProcessUtils {
-         
+    public static class ProcessUtils
+    {
+
 
         /// <summary>
         /// Get the owner of a process using WMI
@@ -27,7 +30,8 @@ namespace Cognite.Simulator.Utils
         /// <exception cref="Exception">Thrown when the process is not found or access is denied</exception>
         public static string GetProcessOwnerWmi(int processId)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
                 throw new PlatformNotSupportedException("This method is only supported on Windows");
             }
 
@@ -49,28 +53,34 @@ namespace Cognite.Simulator.Utils
 
             throw new Exception("Process not found");
         }
-        
-        private static void KillProcessUnsafe(string processId, ILogger logger) {
+
+        private static void KillProcessUnsafe(string processId, ILogger logger)
+        {
             Process[] processes = Process.GetProcessesByName(processId);
             logger.LogDebug("Searching for process : " + processId);
             logger.LogDebug("Found {Count} matching processes", processes.Length);
             bool found = false;
-    
-            foreach (Process process in processes) {
+
+            foreach (Process process in processes)
+            {
                 string owner = GetProcessOwnerWmi(process.Id);
                 logger.LogDebug($"Found process . Process owner is : {owner.ToLower()} . Current user is : {GetCurrentUsername().ToLower()}");
-        
-                if (owner.ToLower() == GetCurrentUsername().ToLower()) {
+
+                if (owner.ToLower() == GetCurrentUsername().ToLower())
+                {
                     logger.LogInformation("Killing process with PID {PID}", process.Id);
                     process.Kill();
                     process.WaitForExit();
                     found = true;
-                } else {
+                }
+                else
+                {
                     logger.LogWarning("Process with PID {PID} is owned by a different user ({Owner}). Skipping.", process.Id, owner);
                 }
             }
-    
-            if (!found) {
+
+            if (!found)
+            {
                 throw new Exception("No processes found to kill for the current user");
             }
         }
@@ -80,10 +90,14 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         /// <param name="processId"></param>
         /// <param name="logger"></param>
-        public static void KillProcess(string processId, ILogger logger) {
-            try {
+        public static void KillProcess(string processId, ILogger logger)
+        {
+            try
+            {
                 KillProcessUnsafe(processId, logger);
-            } catch (Exception e) {
+            }
+            catch (Exception e)
+            {
                 logger.LogError("Failed to kill process: {Message}", e.Message);
                 throw;
             }
@@ -91,7 +105,8 @@ namespace Cognite.Simulator.Utils
 
         public static string GetCurrentUsername()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
                 throw new PlatformNotSupportedException("This method is only supported on Windows");
             }
             return WindowsIdentity.GetCurrent().Name;

--- a/Cognite.Simulator.Utils/RoutineImplementationBase.cs
+++ b/Cognite.Simulator.Utils/RoutineImplementationBase.cs
@@ -1,6 +1,3 @@
-using Cognite.Simulator.Utils;
-using CogniteSdk.Alpha;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -8,6 +5,12 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Cognite.Simulator.Utils;
+
+using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils
 {
@@ -33,7 +36,7 @@ namespace Cognite.Simulator.Utils
         public RoutineImplementationBase(
             SimulatorRoutineRevision routineRevision,
             Dictionary<string, SimulatorValueItem> inputData,
-            ILogger logger )
+            ILogger logger)
         {
             if (routineRevision == null)
             {
@@ -139,7 +142,7 @@ namespace Cognite.Simulator.Utils
                             throw new SimulationRoutineException($"Invalid stage step: {step.StepType}", stepNumber: step.Order);
                     };
                 }
-                catch (Exception e) when (e is SimulationException )
+                catch (Exception e) when (e is SimulationException)
                 {
                     throw new SimulationRoutineException(e.Message, stepNumber: step.Order);
                 }
@@ -165,15 +168,15 @@ namespace Cognite.Simulator.Utils
             }
             var extraArgs = arguments.Where(s => s.Key != "referenceId")
                 .ToDictionary(dict => dict.Key, dict => dict.Value);
-            
+
             var matchingOutputs = _config.Outputs.Where(i => i.ReferenceId == argRefId).ToList();
             if (matchingOutputs.Any())
-                {
-                    var output = matchingOutputs.First();
-                    string flattenedArguments = SimulatorLoggingUtils.FlattenDictionary(extraArgs);
-                    _logger.LogDebug("Getting output for Reference Id: {Output}. Arguments: {Arguments}", output.ReferenceId, flattenedArguments);
-                    _simulationResults[output.ReferenceId] = GetOutput(output, extraArgs, token);
-                }
+            {
+                var output = matchingOutputs.First();
+                string flattenedArguments = SimulatorLoggingUtils.FlattenDictionary(extraArgs);
+                _logger.LogDebug("Getting output for Reference Id: {Output}. Arguments: {Arguments}", output.ReferenceId, flattenedArguments);
+                _simulationResults[output.ReferenceId] = GetOutput(output, extraArgs, token);
+            }
             else
             {
                 throw new SimulationException($"Get error: Output with key {argRefId} not found");

--- a/Cognite.Simulator.Utils/RoutineImplementationBase.cs
+++ b/Cognite.Simulator.Utils/RoutineImplementationBase.cs
@@ -140,7 +140,7 @@ namespace Cognite.Simulator.Utils
                                 break;
                             }
                             throw new SimulationRoutineException($"Invalid stage step: {step.StepType}", stepNumber: step.Order);
-                    };
+                    }
                 }
                 catch (Exception e) when (e is SimulationException)
                 {

--- a/Cognite.Simulator.Utils/RoutineLibraryBase.cs
+++ b/Cognite.Simulator.Utils/RoutineLibraryBase.cs
@@ -1,17 +1,20 @@
-﻿using Cognite.Extractor.StateStorage;
-using Cognite.Extractor.Utils;
-using Cognite.Simulator.Extensions;
-using Cognite.Simulator.Utils.Automation;
-using CogniteSdk.Alpha;
-using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Cognite.Extensions;
 using Cognite.Extractor.Common;
-using System.Collections.Concurrent;
+using Cognite.Extractor.StateStorage;
+using Cognite.Extractor.Utils;
+using Cognite.Simulator.Extensions;
+using Cognite.Simulator.Utils.Automation;
+
+using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.Logging;
 
 namespace Cognite.Simulator.Utils
 {
@@ -32,7 +35,7 @@ namespace Cognite.Simulator.Utils
         private SimulatorCreate _simulatorDefinition;
         /// <inheritdoc/>
         protected CogniteSdk.Resources.Alpha.SimulatorsResource CdfSimulatorResources { get; private set; }
-        
+
         /// <summary>
         ///  In memory extraction state for the library.
         ///  Keeps track of the time range of routine revisions that have been fetched.
@@ -69,14 +72,14 @@ namespace Cognite.Simulator.Utils
             LibState = new BaseExtractionState("RoutineLibraryState");
             _simulatorDefinition = simulatorDefinition;
         }
-        
+
 
         /// <summary>
         /// Initializes the routine library. Finds entities in CDF and caches them in memory.
         /// </summary>
         /// <param name="token">Cancellation token</param>
         public async Task Init(CancellationToken token)
-        {            
+        {
             await ReadRoutineRevisions(true, token).ConfigureAwait(false);
         }
 
@@ -87,7 +90,8 @@ namespace Cognite.Simulator.Utils
         private async Task<V> TryReadRemoteRoutineRevision(string routineRevisionExternalId)
         {
             _logger.LogInformation("Local routine revision {Id} not found, attempting to fetch from remote", routineRevisionExternalId);
-            try {
+            try
+            {
                 var routineRevisionRes = await CdfSimulatorResources.RetrieveSimulatorRoutineRevisionsAsync(
                     new List<CogniteSdk.Identity> { new CogniteSdk.Identity(routineRevisionExternalId) }
                 ).ConfigureAwait(false);
@@ -96,7 +100,9 @@ namespace Cognite.Simulator.Utils
                 {
                     return ReadAndSaveRoutineRevision(routineRevision);
                 }
-            } catch (CogniteException e) {
+            }
+            catch (CogniteException e)
+            {
                 _logger.LogError(e, "Cannot find routine revision {Id} on remote", routineRevisionExternalId);
             }
             return null;
@@ -138,13 +144,16 @@ namespace Cognite.Simulator.Utils
 
             bool exists = false;
 
-            try {
+            try
+            {
                 var revisionRes = await CdfSimulatorResources.RetrieveSimulatorRoutineRevisionsAsync(
                     new List<CogniteSdk.Identity> { new CogniteSdk.Identity(config.Id) },
                     token
                 ).ConfigureAwait(false);
                 exists = revisionRes.Count() == 1;
-            } catch (CogniteException e) {
+            }
+            catch (CogniteException e)
+            {
                 _logger.LogError(e, "Cannot find routine revision {Id} on remote", config.Id);
             }
 
@@ -194,16 +203,20 @@ namespace Cognite.Simulator.Utils
         /// Convert a routine revision to a configuration object of type <typeparamref name="V"/>
         /// Generally not advised on overriding this method.
         /// </summary>
-        protected virtual V LocalConfigurationFromRoutine(SimulatorRoutineRevision routineRevision) {
-            return (V) routineRevision;
+        protected virtual V LocalConfigurationFromRoutine(SimulatorRoutineRevision routineRevision)
+        {
+            return (V)routineRevision;
         }
 
-        private V ReadAndSaveRoutineRevision(SimulatorRoutineRevision routineRev) {
-            
+        private V ReadAndSaveRoutineRevision(SimulatorRoutineRevision routineRev)
+        {
+
             V newRevision = LocalConfigurationFromRoutine(routineRev);
-            
-            var result = RoutineRevisions.AddOrUpdate(routineRev.Id.ToString(), newRevision, (key, oldValue) => {
-                if (newRevision.CreatedTime < oldValue.CreatedTime) {
+
+            var result = RoutineRevisions.AddOrUpdate(routineRev.Id.ToString(), newRevision, (key, oldValue) =>
+            {
+                if (newRevision.CreatedTime < oldValue.CreatedTime)
+                {
                     return oldValue;
                 }
                 return newRevision;
@@ -228,7 +241,7 @@ namespace Cognite.Simulator.Utils
                 );
             }
 
-            long createdAfter = 
+            long createdAfter =
                 !init && !LibState.DestinationExtractedRange.IsEmpty ?
                     LibState.DestinationExtractedRange.Last.ToUnixTimeMilliseconds() : 0;
 
@@ -239,7 +252,7 @@ namespace Cognite.Simulator.Utils
                     {
                         // TODO filter by simulatorIntegrationExternalIds
                         SimulatorExternalIds = [_simulatorDefinition.ExternalId],
-                        CreatedTime = new CogniteSdk.TimeRange() {  Min = createdAfter + 1 },
+                        CreatedTime = new CogniteSdk.TimeRange() { Min = createdAfter + 1 },
                     },
                     Limit = PaginationLimit,
                     IncludeAllFields = true
@@ -307,7 +320,7 @@ namespace Cognite.Simulator.Utils
         /// Initializes the library
         /// </summary>
         Task Init(CancellationToken token);
-    
+
         /// <summary>
         /// Get the simulation configuration object with the given property
         /// </summary>

--- a/Cognite.Simulator.Utils/ScopedRemoteApiSink.cs
+++ b/Cognite.Simulator.Utils/ScopedRemoteApiSink.cs
@@ -1,17 +1,20 @@
-using Serilog.Core;
-using Serilog.Events;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+
 using Cognite.Simulator.Extensions;
+
 using CogniteSdk.Alpha;
 using CogniteSdk.Resources.Alpha;
-using System.Collections.Concurrent;
-using System.Threading;
 
-using System.Linq;
+using Serilog.Core;
+using Serilog.Events;
 
-namespace Cognite.Simulator.Utils {
+namespace Cognite.Simulator.Utils
+{
 
     /// <summary>
     /// Represents a sink for emitting log events to a remote API.
@@ -27,15 +30,18 @@ namespace Cognite.Simulator.Utils {
         private long? defaultLogId;
         private static readonly LogEventLevel DefaultMinimumLevel = LogEventLevel.Warning;
         private static readonly LogEventLevel[] AllowedLogLevels = new[] { LogEventLevel.Debug, LogEventLevel.Information, LogEventLevel.Warning, LogEventLevel.Error };
-        
+
         /// <summary>
         /// Create a scoped api sink
         /// </summary>
         /// <param name="loggerConfig">The logger configuration</param>
-        public ScopedRemoteApiSink(LoggerConfig loggerConfig) : base(){
-            if (loggerConfig != null) {
+        public ScopedRemoteApiSink(LoggerConfig loggerConfig) : base()
+        {
+            if (loggerConfig != null)
+            {
                 enabled = loggerConfig.Remote == null || loggerConfig.Remote.Enabled;
-                if (enabled) {
+                if (enabled)
+                {
                     minSeverityLevel = ParseLogLevel(loggerConfig.Remote?.Level);
                 }
             }
@@ -47,7 +53,8 @@ namespace Cognite.Simulator.Utils {
             {
                 return DefaultMinimumLevel;
             }
-            if(!Enum.TryParse(level, true, out LogEventLevel logLevel)) {
+            if (!Enum.TryParse(level, true, out LogEventLevel logLevel))
+            {
                 throw new ArgumentException($"Unknown minimum log level for remote API: {level}");
             }
             return logLevel;
@@ -68,11 +75,11 @@ namespace Cognite.Simulator.Utils {
         /// <param name="logEvent">The log event to emit.</param>
         public void Emit(LogEvent logEvent)
         {
-            if(!enabled)
+            if (!enabled)
             {
                 return;
             }
-            
+
             if (logEvent == null)
             {
                 throw new ArgumentNullException(nameof(logEvent));
@@ -80,7 +87,8 @@ namespace Cognite.Simulator.Utils {
 
             var minLevel = minSeverityLevel;
 
-            if (logEvent.Properties.TryGetValue("Severity", out var value) && value is ScalarValue sv && sv.Value is string overrideSeverity) {
+            if (logEvent.Properties.TryGetValue("Severity", out var value) && value is ScalarValue sv && sv.Value is string overrideSeverity)
+            {
                 minLevel = ParseLogLevel(overrideSeverity);
             }
 
@@ -99,11 +107,13 @@ namespace Cognite.Simulator.Utils {
 
             logEvent.Properties.TryGetValue("LogId", out var logId);
 
-            if (logId == null && defaultLogId == null) {
+            if (logId == null && defaultLogId == null)
+            {
                 return;
             }
             long logIdLong = logId == null ? defaultLogId.Value : long.Parse(logId.ToString());
-            if (logIdLong == 0) {
+            if (logIdLong == 0)
+            {
                 return;
             }
             // Customize the log data to send to the remote API
@@ -114,11 +124,12 @@ namespace Cognite.Simulator.Utils {
                 Message = logEvent.RenderMessage(),
             };
 
-            logBuffer.AddOrUpdate(logIdLong, new List<SimulatorLogDataEntry>(){ logData }, (key, oldValue) => {
+            logBuffer.AddOrUpdate(logIdLong, new List<SimulatorLogDataEntry>() { logData }, (key, oldValue) =>
+            {
                 oldValue.Add(logData);
                 return oldValue;
             });
-            
+
         }
 
         /// <summary>
@@ -136,7 +147,8 @@ namespace Cognite.Simulator.Utils {
         {
             foreach (var log in logBuffer)
             {
-                try {
+                try
+                {
                     // to make sure we remove only the logs that were sent to the remote API
                     if (logBuffer.TryRemove(log.Key, out var logData))
                     {
@@ -144,8 +156,8 @@ namespace Cognite.Simulator.Utils {
                             log.Key,
                             logData,
                             token
-                        ).ConfigureAwait(false);   
-                        
+                        ).ConfigureAwait(false);
+
                     }
                 }
                 catch (Exception ex)

--- a/Cognite.Simulator.Utils/SimulationRunnerBase.cs
+++ b/Cognite.Simulator.Utils/SimulationRunnerBase.cs
@@ -1,17 +1,21 @@
-﻿using Cognite.Extractor.Common;
-using Cognite.Extractor.Utils;
-using Cognite.Simulator.Extensions;
-using Cognite.Simulator.Utils.Automation;
-using CogniteSdk;
-using CogniteSdk.Alpha;
-using CogniteSdk.Resources.Alpha;
-using Microsoft.Extensions.Logging;
-using Serilog.Context;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Cognite.Extractor.Common;
+using Cognite.Extractor.Utils;
+using Cognite.Simulator.Extensions;
+using Cognite.Simulator.Utils.Automation;
+
+using CogniteSdk;
+using CogniteSdk.Alpha;
+using CogniteSdk.Resources.Alpha;
+
+using Microsoft.Extensions.Logging;
+
+using Serilog.Context;
 
 using static Cognite.Simulator.Utils.SimulatorLoggingUtils;
 
@@ -25,7 +29,7 @@ namespace Cognite.Simulator.Utils
     /// <typeparam name="T">Type of model state objects</typeparam>
     /// <typeparam name="V">Type of simulation configuration objects</typeparam>
     public abstract class SimulationRunnerBase<A, T, V>
-        where A: AutomationConfig
+        where A : AutomationConfig
         where T : ModelStateBase
         where V : SimulatorRoutineRevision
     {
@@ -37,7 +41,7 @@ namespace Cognite.Simulator.Utils
         /// <summary>
         /// Library containing the simulator model files
         /// </summary>
-        protected IModelProvider<A,T> ModelLibrary { get; }
+        protected IModelProvider<A, T> ModelLibrary { get; }
 
         /// <summary>
         /// Library containing the simulation configuration files
@@ -62,7 +66,7 @@ namespace Cognite.Simulator.Utils
             ConnectorConfig connectorConfig,
             SimulatorCreate simulatorDefinition,
             CogniteDestination cdf,
-            IModelProvider<A,T> modelLibrary,
+            IModelProvider<A, T> modelLibrary,
             IRoutineProvider<V> routineLibrary,
             ILogger logger)
         {
@@ -276,7 +280,7 @@ namespace Cognite.Simulator.Utils
             {
                 return (model, null);
             }
-            
+
             return (model, routineRev);
         }
 
@@ -360,11 +364,11 @@ namespace Cognite.Simulator.Utils
                 token).ConfigureAwait(false);
 
             var configObj = routineRevision.Configuration;
-            
+
             // Determine the validation end time
             // If the run contains a validation end overwrite, use that instead of the current time
-            var validationEnd = runItem.Run.RunTime.HasValue? CogniteTime.FromUnixTimeMilliseconds(runItem.Run.RunTime.Value) : startTime;
-            
+            var validationEnd = runItem.Run.RunTime.HasValue ? CogniteTime.FromUnixTimeMilliseconds(runItem.Run.RunTime.Value) : startTime;
+
             SamplingConfiguration samplingConfiguration = null;
             try
             {
@@ -377,7 +381,7 @@ namespace Cognite.Simulator.Utils
                         configObj,
                         validationEnd,
                         token).ConfigureAwait(false);
-                    
+
                     // if the sampling range is not null, use it to create the sampling configuration
                     // this should always pass, as the validation check should throw an exception if it fails
                     if (samplingRange.Max.HasValue)
@@ -386,7 +390,7 @@ namespace Cognite.Simulator.Utils
                             start: samplingRange.Min,
                             samplingPosition: SamplingPosition.Midpoint
                         );
-                } 
+                }
                 // if data sampling is not enabled, we do not sample data, but instead use the latest datapoint before
                 // validation end and the simulation time becomes also the validation end
                 else
@@ -395,7 +399,7 @@ namespace Cognite.Simulator.Utils
                         end: validationEnd.ToUnixTimeMilliseconds()
                     );
                 }
-                
+
                 _logger.LogInformation("Running routine revision {ExternalId} for model {ModelExternalId}. Simulation time: {Time}",
                     routineRevision.ExternalId,
                     routineRevision.ModelExternalId,
@@ -476,8 +480,9 @@ namespace Cognite.Simulator.Utils
         /// Throws an exception if the simulation run is too old or in an invalid state
         /// </summary>
         /// <param name="maxAgeSeconds">Maximum age of the simulation run in seconds</param>
-        public void ValidateReadinessForExecution(int maxAgeSeconds = 3600) {
-          
+        public void ValidateReadinessForExecution(int maxAgeSeconds = 3600)
+        {
+
             if (Run.CreatedTime < DateTime.UtcNow.AddSeconds(-1 * maxAgeSeconds).ToUnixTimeMilliseconds())
             {
                 throw new ConnectorException($"Simulation has timed out because it is older than {maxAgeSeconds} second(s)");

--- a/Cognite.Simulator.Utils/SimulationScheduler.cs
+++ b/Cognite.Simulator.Utils/SimulationScheduler.cs
@@ -4,13 +4,15 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.Extensions.Logging;
-using NCrontab;
-
 using Cognite.Extractor.Common;
 using Cognite.Extractor.Utils;
 using Cognite.Simulator.Utils.Automation;
+
 using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.Logging;
+
+using NCrontab;
 
 
 namespace Cognite.Simulator.Utils
@@ -222,7 +224,7 @@ namespace Cognite.Simulator.Utils
             var now = DateTime.UtcNow;
             var nextOccurrence = schedule.GetNextOccurrence(now);
             var delay = nextOccurrence - now;
-            
+
             // Get the next occurrence time. Since cron expressions can go as far as minutes, we floor it to the
             // nearest minute, just to make sure the cron is respected
             var nextOccurrenceMs = nextOccurrence.ToUnixTimeMilliseconds();

--- a/Cognite.Simulator.Utils/StateUtils.cs
+++ b/Cognite.Simulator.Utils/StateUtils.cs
@@ -1,12 +1,13 @@
-﻿using Cognite.Extensions;
-using Cognite.Extractor.StateStorage;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Cognite.Extensions;
+using Cognite.Extractor.StateStorage;
 
 namespace Cognite.Simulator.Utils
 {
@@ -21,7 +22,9 @@ namespace Cognite.Simulator.Utils
             {
                 var dirPath = Path.GetDirectoryName(filePath);
                 DeleteLocalDirectory(dirPath);
-            } else {
+            }
+            else
+            {
                 DeleteLocalFile(filePath);
             }
         }
@@ -30,7 +33,7 @@ namespace Cognite.Simulator.Utils
             this LiteDBStateStore store,
             string tableName,
             HashSet<string> idsToKeep)
-        {    
+        {
             var col = store.Database.GetCollection<FileStatePoco>(tableName);
             var stateToDelete = col
                 .Find(s => !idsToKeep.Contains(s.Id))
@@ -64,9 +67,10 @@ namespace Cognite.Simulator.Utils
                 .ConfigureAwait(false);
             foreach (var (state, withFile) in states)
             {
-                if (withFile) {
+                if (withFile)
+                {
                     DeleteFileAndDirectory(state.FilePath, state.IsInDirectory);
-                }   
+                }
             }
         }
 

--- a/Sample.BasicComConnector/ConnectorRuntime.cs
+++ b/Sample.BasicComConnector/ConnectorRuntime.cs
@@ -1,11 +1,15 @@
 using Cognite.Simulator.Utils;
 using Cognite.Simulator.Utils.Automation;
+
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.DependencyInjection;
 
-public static class ConnectorRuntime {
+public static class ConnectorRuntime
+{
 
-    public static void Init() {
+    public static void Init()
+    {
         DefaultConnectorRuntime<NewSimAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.ConfigureServices = ConfigureServices;
         DefaultConnectorRuntime<NewSimAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.ConnectorName = "NewSim";
         DefaultConnectorRuntime<NewSimAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.SimulatorDefinition = SimulatorDefinition.Get();
@@ -14,8 +18,9 @@ public static class ConnectorRuntime {
     {
         services.AddScoped<ISimulatorClient<DefaultModelFilestate, SimulatorRoutineRevision>, NewSimClient>();
     }
-    
-    public static async Task RunStandalone() {
+
+    public static async Task RunStandalone()
+    {
         Init();
         await DefaultConnectorRuntime<NewSimAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.RunStandalone().ConfigureAwait(false);
     }

--- a/Sample.BasicComConnector/NewSimClient.cs
+++ b/Sample.BasicComConnector/NewSimClient.cs
@@ -1,6 +1,8 @@
 using Cognite.Simulator.Utils;
 using Cognite.Simulator.Utils.Automation;
+
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.Logging;
 
 public class NewSimClient : AutomationClient, ISimulatorClient<DefaultModelFilestate, SimulatorRoutineRevision>

--- a/Sample.BasicComConnector/NewSimRoutine.cs
+++ b/Sample.BasicComConnector/NewSimRoutine.cs
@@ -1,5 +1,7 @@
 using Cognite.Simulator.Utils;
+
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.Logging;
 
 public class NewSimRoutine : RoutineImplementationBase
@@ -24,11 +26,14 @@ public class NewSimRoutine : RoutineImplementationBase
         {
             var rawValue = (input.Value as SimulatorValue.Double)?.Value ?? 0;
             worksheet.Cells[row, col].Value = rawValue;
-        } else if (input.ValueType == SimulatorValueType.STRING)
+        }
+        else if (input.ValueType == SimulatorValueType.STRING)
         {
             var rawValue = (input.Value as SimulatorValue.String)?.Value;
             worksheet.Cells[row, col].Formula = rawValue;
-        } else {
+        }
+        else
+        {
             throw new NotImplementedException($"{input.ValueType} not implemented");
         }
 
@@ -51,7 +56,7 @@ public class NewSimRoutine : RoutineImplementationBase
             throw new NotImplementedException($"{outputConfig.ValueType} value type not implemented");
         }
 
-        var rawValue = (double) cell.Value;
+        var rawValue = (double)cell.Value;
         SimulatorValue value = new SimulatorValue.Double(rawValue);
 
         var simulationObjectRef = new Dictionary<string, string> { { "row", rowStr }, { "col", colStr } };

--- a/Sample.BasicComConnector/SimulatorDefinition.cs
+++ b/Sample.BasicComConnector/SimulatorDefinition.cs
@@ -1,19 +1,21 @@
 using CogniteSdk.Alpha;
 
-static class SimulatorDefinition {
-    public static SimulatorCreate Get() {
+static class SimulatorDefinition
+{
+    public static SimulatorCreate Get()
+    {
         return new SimulatorCreate()
-            {
-                ExternalId = "NewSim",
-                Name = "NewSim",
-                FileExtensionTypes = new List<string> { "xlsx" },
-                ModelTypes = new List<SimulatorModelType> {
+        {
+            ExternalId = "NewSim",
+            Name = "NewSim",
+            FileExtensionTypes = new List<string> { "xlsx" },
+            ModelTypes = new List<SimulatorModelType> {
                     new SimulatorModelType {
                         Name = "Steady State",
                         Key = "SteadyState",
                     }
                 },
-                StepFields = new List<SimulatorStepField> {
+            StepFields = new List<SimulatorStepField> {
                     new SimulatorStepField {
                         StepType = "get/set",
                         Fields = new List<SimulatorStepFieldParam> {
@@ -35,7 +37,7 @@ static class SimulatorDefinition {
                         },
                     },
                 },
-                UnitQuantities = new List<SimulatorUnitQuantity>() {
+            UnitQuantities = new List<SimulatorUnitQuantity>() {
                     new SimulatorUnitQuantity {
                         Name = "Temperature",
                         Label = "Temperature",
@@ -47,6 +49,6 @@ static class SimulatorDefinition {
                         },
                     },
                 },
-            };
+        };
     }
 }

--- a/Sample.Calculator.Simulator/Program.cs
+++ b/Sample.Calculator.Simulator/Program.cs
@@ -1,7 +1,10 @@
 ﻿using Cognite.Simulator.Utils;
 using Cognite.Simulator.Utils.Automation;
+
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.DependencyInjection;
+
 using SampleConnector;
 
 await SampleConnectorNamespace.SampleConnector.Run().ConfigureAwait(false);

--- a/Sample.Calculator.Simulator/Simulator.cs
+++ b/Sample.Calculator.Simulator/Simulator.cs
@@ -1,15 +1,20 @@
 using Cognite.Simulator.Utils;
+
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.Logging;
+
 using static SampleConnectorNamespace.SampleConnector;
 
-public class CalculatorSimulatorClient : 
-        ISimulatorClient<CalculatorModelFilestate, SimulatorRoutineRevision> {
+public class CalculatorSimulatorClient :
+        ISimulatorClient<CalculatorModelFilestate, SimulatorRoutineRevision>
+{
 
-    
+
     private readonly ILogger<CalculatorSimulatorClient> _logger;
 
-    public CalculatorSimulatorClient(ILogger<CalculatorSimulatorClient> logger, DefaultConfig<CustomAutomationConfig> config) {
+    public CalculatorSimulatorClient(ILogger<CalculatorSimulatorClient> logger, DefaultConfig<CustomAutomationConfig> config)
+    {
         _logger = logger;
     }
 
@@ -33,11 +38,12 @@ public class CalculatorSimulatorClient :
     }
 
     public Task<Dictionary<string, SimulatorValueItem>> RunSimulation(
-        CalculatorModelFilestate modelState, 
-        SimulatorRoutineRevision routineRevision, 
+        CalculatorModelFilestate modelState,
+        SimulatorRoutineRevision routineRevision,
         Dictionary<string, SimulatorValueItem> inputData,
         CancellationToken token
-    ) {
+    )
+    {
         _logger.LogInformation("CalculatorClient Running a simulation");
         try
         {
@@ -54,7 +60,7 @@ public class CalculatorSimulatorClient :
         finally
         {
         }
-        
+
     }
 
     public Task TestConnection(CancellationToken token)
@@ -72,7 +78,8 @@ internal class CalculatorRoutine : RoutineImplementationBase
     public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig, Dictionary<string, string> arguments, CancellationToken token)
     {
         Console.WriteLine("Handling outputs");
-        var resultItem = new SimulatorValueItem() {
+        var resultItem = new SimulatorValueItem()
+        {
             SimulatorObjectReference = new Dictionary<string, string> {
                 { "objectName", "a" },
                 { "objectProperty", "b" },

--- a/Sample.Calculator.Simulator/SimulatorAutomation.cs
+++ b/Sample.Calculator.Simulator/SimulatorAutomation.cs
@@ -1,8 +1,11 @@
 using Cognite.Extractor.StateStorage;
 using Cognite.Simulator.Utils;
 using Cognite.Simulator.Utils.Automation;
+
 using CogniteSdk.Alpha;
+
 using Microsoft.Extensions.Logging;
+
 using static SampleConnectorNamespace.SampleConnector;
 
 public class CalculatorModelFilestate : ModelStateBase
@@ -76,7 +79,8 @@ public class CalculatorSimulatorAutomationClient :
             throw new Exception("State is not defined");
         }
         Random random = new Random();
-        await Task.Run(() => {
+        await Task.Run(() =>
+        {
             Thread.Sleep(200);
         }, _token).ConfigureAwait(false);
         state.ModelType = "PARSED" + random.Next().ToString() + "abc";
@@ -103,7 +107,8 @@ public class CalculatorSimulatorAutomationClient :
         CancellationToken token
     )
     {
-        if (modelState == null) {
+        if (modelState == null)
+        {
             throw new Exception("Model state is not defined");
         }
         _logger.LogInformation("CalculatorClient Running a simulation");

--- a/Sample.Calculator.Simulator/SimulatorDefinition.cs
+++ b/Sample.Calculator.Simulator/SimulatorDefinition.cs
@@ -1,20 +1,23 @@
 using CogniteSdk.Alpha;
 
-namespace SampleConnector{
-    public static class SimulatorDefinition {
-        public static SimulatorCreate Get() {
+namespace SampleConnector
+{
+    public static class SimulatorDefinition
+    {
+        public static SimulatorCreate Get()
+        {
             return new SimulatorCreate()
-                {
-                    ExternalId = "CALCULATOR-DEMO",
-                    Name = "CALCULATOR-DEMO",
-                    FileExtensionTypes = new List<string> { "demo" },
-                    ModelTypes = new List<SimulatorModelType> {
+            {
+                ExternalId = "CALCULATOR-DEMO",
+                Name = "CALCULATOR-DEMO",
+                FileExtensionTypes = new List<string> { "demo" },
+                ModelTypes = new List<SimulatorModelType> {
                         new SimulatorModelType {
                             Name = "General",
                             Key = "General",
                         },
                     },
-                    StepFields = new List<SimulatorStepField> {
+                StepFields = new List<SimulatorStepField> {
                         new SimulatorStepField {
                             StepType = "get/set",
                             Fields = new List<SimulatorStepFieldParam> {
@@ -36,7 +39,7 @@ namespace SampleConnector{
                             },
                         },
                     },
-                    UnitQuantities = new List<SimulatorUnitQuantity> {
+                UnitQuantities = new List<SimulatorUnitQuantity> {
                         new SimulatorUnitQuantity {
                             Name = "LiqRate/GasRate",
                             Label = "Liquid Gas Rate",
@@ -72,7 +75,7 @@ namespace SampleConnector{
                             },
                         },
                     }
-                };
+            };
         }
     }
 }


### PR DESCRIPTION
This PR introduces a pre-commit rule for formatting dotnet using the built-in tool: `dotnet format`.
The CI check for formatting is also included.

The reason for the size of this PR is the auto-generated changes.