### PR TITLE
docs: fix COM connector example

### DIFF
--- a/Sample.BasicComConnector/SimulatorDefinition.cs
+++ b/Sample.BasicComConnector/SimulatorDefinition.cs
@@ -20,9 +20,14 @@ static class SimulatorDefinition
                         StepType = "get/set",
                         Fields = new List<SimulatorStepFieldParam> {
                             new SimulatorStepFieldParam {
-                                Name = "address",
-                                Label = "Address",
-                                Info = "Enter the address to set",
+                                Name = "row",
+                                Label = "Row",
+                                Info = "Row number of the cell in the table",
+                            },
+                            new SimulatorStepFieldParam {
+                                Name = "col",
+                                Label = "Column",
+                                Info = "Column number of the cell in the table",
                             },
                         },
                     },

--- a/docfx_project/docs/create-connector.md
+++ b/docfx_project/docs/create-connector.md
@@ -88,9 +88,14 @@ static class SimulatorDefinition {
                         StepType = "get/set",
                         Fields = new List<SimulatorStepFieldParam> {
                             new SimulatorStepFieldParam {
-                                Name = "address",
-                                Label = "Address",
-                                Info = "Enter the address to set",
+                                Name = "row",
+                                Label = "Row",
+                                Info = "Row number of the cell in the table",
+                            },
+                            new SimulatorStepFieldParam {
+                                Name = "col",
+                                Label = "Column",
+                                Info = "Column number of the cell in the table",
                             },
                         },
                     },


### PR DESCRIPTION
this fixes the tutorial (example COM connector) to use rows, columns as input fields instead of address (excel doesn't call it address)

this was probably copied earlier from PETEX connector by mistake