### PR TITLE
fix: don't call extraction pipeline when disabled

### DIFF
--- a/Cognite.Simulator.Tests/UtilsTests/ExtPipelineUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ExtPipelineUnitTest.cs
@@ -30,6 +30,12 @@ namespace Cognite.Simulator.Tests.UtilsTests
             new SimpleRequestMocker(uri => uri.EndsWith("/extpipes"), MockExtPipesEndpoint, 1).ShouldBeCalled(Times.Once()),
             new SimpleRequestMocker(uri => uri.EndsWith("/extpipes/runs"), MockExtPipesEndpoint),
         };
+        private static readonly ConnectorConfig ConnectorConfig = new ConnectorConfig
+        {
+            NamePrefix = SeedData.TestIntegrationExternalId,
+            DataSetId = SeedData.TestDataSetId,
+            PipelineNotification = new PipelineNotificationConfig(),
+        };
 
         [Fact]
         /// <summary>
@@ -53,20 +59,14 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var mockedLogger = new Mock<ILogger<ExtractionPipeline>>();
             services.AddSingleton(mockedLogger.Object);
 
-            var connectorConfig = new ConnectorConfig
-            {
-                NamePrefix = SeedData.TestIntegrationExternalId,
-                DataSetId = SeedData.TestDataSetId,
-                PipelineNotification = new PipelineNotificationConfig(),
-            };
-            services.AddExtractionPipeline(connectorConfig);
+            services.AddExtractionPipeline(ConnectorConfig);
 
             using var provider = services.BuildServiceProvider();
 
             var extPipeline = provider.GetRequiredService<ExtractionPipeline>();
 
             // Act
-            await extPipeline.Init(connectorConfig, CancellationToken.None);
+            await extPipeline.Init(ConnectorConfig, CancellationToken.None);
 
             using var tokenSource = new CancellationTokenSource();
             tokenSource.CancelAfter(TimeSpan.FromSeconds(5));
@@ -108,13 +108,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var mockedLogger = new Mock<ILogger<ExtractionPipeline>>();
             services.AddSingleton(mockedLogger.Object);
 
-            var connectorConfig = new ConnectorConfig
-            {
-                NamePrefix = SeedData.TestIntegrationExternalId,
-                DataSetId = SeedData.TestDataSetId,
-                PipelineNotification = new PipelineNotificationConfig(),
-            };
-            services.AddExtractionPipeline(connectorConfig);
+            services.AddExtractionPipeline(ConnectorConfig);
 
             using var provider = services.BuildServiceProvider();
 
@@ -124,7 +118,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var extPipeline = provider.GetRequiredService<ExtractionPipeline>();
 
             // Act
-            await extPipeline.Init(connectorConfig, CancellationToken.None);
+            await extPipeline.Init(ConnectorConfig, CancellationToken.None);
 
             using var tokenSource = new CancellationTokenSource();
             tokenSource.CancelAfter(TimeSpan.FromSeconds(5));

--- a/Cognite.Simulator.Utils/ExtractionPipeline.cs
+++ b/Cognite.Simulator.Utils/ExtractionPipeline.cs
@@ -175,6 +175,10 @@ namespace Cognite.Simulator.Utils
         /// <param name="token">Cancellation token</param>
         public async Task PipelineUpdate(CancellationToken token)
         {
+            if (_disabled)
+            {
+                return;
+            }
             var startMessage = LastErrorMessage != null ?
                 $"Connector restarted after error: {LastErrorMessage}" :
                 "Connector started";


### PR DESCRIPTION
unfortunately, as a part of the recent change, we introduced a regression by removing an extra check here: https://github.com/cognitedata/dotnet-simulator-utils/commit/800ef10ac98c6f3cd2acd38b95d3d69dfbe2ab94#r154803424
not we get null pointer exception on runtime due to this.

this reverts that change, so now both codepaths work:
1. if ext pipeline is disabled it would never be setup
2. if it is enabled but couldn't initiate on the first try, it will be retried on the next call (that was what the prev PR was about)

added a test to catch this