### PR TITLE
chore(renovate): prevent frequent rebases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "local>cognitedata/renovate-config-public",
     ":automergeMinor"
-  ]
+  ],
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION

https://docs.renovatebot.com/configuration-options/

`rebaseWhen:`
by setting it to only rebase when conflicted, we avoid the constant force-pushes. If we combine it with a merge queue, we don't need to keep up to date with master in order to merge.

This helps with the risk review, as it won't need to reviewed multiple times if master changes.