### PR TITLE
feat(model-library): support original file extension [POFSP-1111]

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build-matrix:

--- a/Cognite.Simulator.Extensions/FilesExtensions.cs
+++ b/Cognite.Simulator.Extensions/FilesExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 using CogniteSdk;
 
@@ -14,7 +15,7 @@ namespace Cognite.Simulator.Extensions
         /// Returns the file extension of a given CDF file.
         /// This is based on the file name and returns the part after the last dot.
         /// </summary>
-        public static string GetExtension(this File file)
+        public static string GetExtension(this CogniteSdk.File file)
         {
             if (file == null)
             {
@@ -26,12 +27,14 @@ namespace Cognite.Simulator.Extensions
                 throw new ArgumentException($"File name cannot be null or empty. File ID: {file.Id}");
             }
 
-            var lastDotIndex = file.Name.LastIndexOf('.');
-            if (lastDotIndex > 0 && lastDotIndex < file.Name.Length - 1)
+            var extension = Path.GetExtension(file.Name);
+
+            if (string.IsNullOrEmpty(extension))
             {
-                return file.Name.Substring(lastDotIndex + 1).ToLowerInvariant();
+                throw new ArgumentException($"File name does not contain a valid extension: {file.Name}");
             }
-            throw new ArgumentException("File name does not contain a valid extension: {fileName}", file.Name);
+
+            return extension.TrimStart('.').ToLowerInvariant();
         }
     }
 }

--- a/Cognite.Simulator.Extensions/FilesExtensions.cs
+++ b/Cognite.Simulator.Extensions/FilesExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+using CogniteSdk;
+
+namespace Cognite.Simulator.Extensions
+{
+    /// <summary>
+    /// Class containing extensions to the CDF Files resource with utility methods
+    /// for simulator integrations
+    /// </summary>
+    public static class FilesExtensions
+    {
+        /// <summary>
+        /// Returns the file extension of a given CDF file.
+        /// This is based on the file name and returns the part after the last dot.
+        /// </summary>
+        public static string GetExtension(this File file)
+        {
+            if (file == null)
+            {
+                throw new ArgumentNullException(nameof(file), "File cannot be null.");
+            }
+
+            if (string.IsNullOrEmpty(file.Name))
+            {
+                throw new ArgumentException($"File name cannot be null or empty. File ID: {file.Id}");
+            }
+
+            var lastDotIndex = file.Name.LastIndexOf('.');
+            if (lastDotIndex > 0 && lastDotIndex < file.Name.Length - 1)
+            {
+                return file.Name.Substring(lastDotIndex + 1).ToLowerInvariant();
+            }
+            throw new ArgumentException("File name does not contain a valid extension: {fileName}", file.Name);
+        }
+    }
+}

--- a/Cognite.Simulator.Extensions/FilesExtensions.cs
+++ b/Cognite.Simulator.Extensions/FilesExtensions.cs
@@ -1,40 +1,37 @@
 ﻿using System;
 using System.IO;
 
-using CogniteSdk;
+namespace Cognite.Simulator.Extensions;
 
-namespace Cognite.Simulator.Extensions
+/// <summary>
+/// Class containing extensions to the CDF Files resource with utility methods
+/// for simulator integrations
+/// </summary>
+public static class FilesExtensions
 {
     /// <summary>
-    /// Class containing extensions to the CDF Files resource with utility methods
-    /// for simulator integrations
+    /// Returns the file extension of a given CDF file.
+    /// This is based on the file name and returns the extension in lowercase without the leading period.
     /// </summary>
-    public static class FilesExtensions
+    public static string GetExtension(this CogniteSdk.File file)
     {
-        /// <summary>
-        /// Returns the file extension of a given CDF file.
-        /// This is based on the file name and returns the part after the last dot.
-        /// </summary>
-        public static string GetExtension(this CogniteSdk.File file)
+        if (file == null)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file), "File cannot be null.");
-            }
-
-            if (string.IsNullOrEmpty(file.Name))
-            {
-                throw new ArgumentException($"File name cannot be null or empty. File ID: {file.Id}");
-            }
-
-            var extension = Path.GetExtension(file.Name);
-
-            if (string.IsNullOrEmpty(extension))
-            {
-                throw new ArgumentException($"File name does not contain a valid extension: {file.Name}");
-            }
-
-            return extension.TrimStart('.').ToLowerInvariant();
+            throw new ArgumentNullException(nameof(file), "File cannot be null.");
         }
+
+        if (string.IsNullOrEmpty(file.Name))
+        {
+            throw new ArgumentException($"File name cannot be null or empty. File ID: {file.Id}");
+        }
+
+        var extension = Path.GetExtension(file.Name);
+
+        if (string.IsNullOrEmpty(extension))
+        {
+            throw new ArgumentException($"File name does not contain a valid extension: {file.Name}");
+        }
+
+        return extension.TrimStart('.').ToLowerInvariant();
     }
 }

--- a/Cognite.Simulator.Tests/ExtensionsTests/FilesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/FilesTest.cs
@@ -17,6 +17,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
         [InlineData("path/to/file.DOC", "doc")]
         [InlineData("multi.part.name.XML", "xml")]
         [InlineData("file.with.dots.in.name.json", "json")]
+        [InlineData(".startswithdot", "startswithdot")]
         public void GetExtension_ValidFileName_ReturnsLowercaseExtension(string fileName, string expectedExtension)
         {
             // Arrange
@@ -63,7 +64,6 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
         [Theory]
         [InlineData("noextension")]
         [InlineData("ends.with.")]
-        [InlineData(".startswithdot")]
         [InlineData("   ")]
         public void GetExtension_InvalidFileName_ThrowsArgumentException(string fileName)
         {

--- a/Cognite.Simulator.Tests/ExtensionsTests/FilesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/FilesTest.cs
@@ -33,6 +33,16 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             Assert.Equal(expectedExtension, extension);
         }
 
+        [Fact]
+        public void GetExtension_NullFile_ThrowsArgumentNullException()
+        {
+            // Arrange
+            File? file = null;
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() => file.GetExtension());
+            Assert.Equal("File cannot be null. (Parameter 'file')", exception.Message);
+        }
+
         [Theory]
         [InlineData("")]
         [InlineData(null)]

--- a/Cognite.Simulator.Tests/ExtensionsTests/FilesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/FilesTest.cs
@@ -15,6 +15,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
         [InlineData("test.txt", "txt")]
         [InlineData("file.PDF", "pdf")]
         [InlineData("path/to/file.DOC", "doc")]
+        [InlineData("back\\slash\\file.txt", "txt")]
         [InlineData("multi.part.name.XML", "xml")]
         [InlineData("file.with.dots.in.name.json", "json")]
         [InlineData(".startswithdot", "startswithdot")]

--- a/Cognite.Simulator.Tests/ExtensionsTests/FilesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/FilesTest.cs
@@ -1,0 +1,72 @@
+using System;
+
+using Cognite.Simulator.Extensions;
+
+using CogniteSdk;
+
+
+using Xunit;
+
+namespace Cognite.Simulator.Tests.ExtensionsTests
+{
+    public class FilesTests
+    {
+        [Theory]
+        [InlineData("test.txt", "txt")]
+        [InlineData("file.PDF", "pdf")]
+        [InlineData("path/to/file.DOC", "doc")]
+        [InlineData("multi.part.name.XML", "xml")]
+        [InlineData("file.with.dots.in.name.json", "json")]
+        public void GetExtension_ValidFileName_ReturnsLowercaseExtension(string fileName, string expectedExtension)
+        {
+            // Arrange
+            var file = new File
+            {
+                Name = fileName,
+                Id = 123
+            };
+
+            // Act
+            var extension = file.GetExtension();
+
+            // Assert
+            Assert.Equal(expectedExtension, extension);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void GetExtension_NullOrEmptyFileName_ThrowsArgumentException(string? fileName)
+        {
+            // Arrange
+            var file = new File
+            {
+                Name = fileName,
+                Id = 123
+            };
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => file.GetExtension());
+            Assert.Contains("File name cannot be null or empty. File ID: 123", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("noextension")]
+        [InlineData("ends.with.")]
+        [InlineData(".startswithdot")]
+        [InlineData("   ")]
+        public void GetExtension_InvalidFileName_ThrowsArgumentException(string fileName)
+        {
+            // Arrange
+            var file = new File
+            {
+                Name = fileName,
+                Id = 123
+            };
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => file.GetExtension());
+            Assert.Contains("File name does not contain a valid extension", exception.Message);
+        }
+    }
+}

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -108,7 +109,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             Assert.True(modelInState.CanRead);
             Assert.False(modelInState.ParsingInfo.Error);
             Assert.True(modelInState.ParsingInfo.Parsed);
-            Assert.EndsWith("/100/100.csv", modelInState.FilePath);
+            Assert.EndsWith(Path.Combine("100", "100.csv"), modelInState.FilePath);
             Assert.Equal("csv", modelInState.FileExtension);
 
             Assert.True(modelInState.Downloaded);

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -29,10 +29,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
         private static readonly IList<SimpleRequestMocker> endpointMockTemplates = new List<SimpleRequestMocker>
         {
             new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
-            new SimpleRequestMocker(uri => uri.EndsWith("/simulators/list") || uri.EndsWith("/simulators") || uri.EndsWith("/simulators/update"), MockSimulatorsEndpoint),
             new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), () => OkItemsResponse(""), 1), // Returns empty to simulate no revisions found on first call
             new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint, 5),
             new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/update"), MockSimulatorModelRevEndpoint, 1),
+            new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
             new SimpleRequestMocker(uri => uri.Contains("/files/downloadlink"), MockFilesDownloadLinkEndpoint, 1),
             new SimpleRequestMocker(uri => uri.Contains("/files/download"), () => MockFilesDownloadEndpoint(1), 1),
             new SimpleRequestMocker(uri => true, () => GoneResponse)
@@ -108,6 +108,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
             Assert.True(modelInState.CanRead);
             Assert.False(modelInState.ParsingInfo.Error);
             Assert.True(modelInState.ParsingInfo.Parsed);
+            Assert.EndsWith("/100/100.csv", modelInState.FilePath);
+            Assert.Equal("csv", modelInState.FileExtension);
 
             Assert.True(modelInState.Downloaded);
             var fileBytes = System.IO.File.ReadAllBytes(modelInState.FilePath);

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
@@ -103,6 +103,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     Assert.Equal(SeedData.TestModelExternalId, modelInState.ModelExternalId);
                     Assert.Equal(revision.VersionNumber, modelInState.Version);
                     Assert.True(modelInState.Processed); // Files get processed as soon as they are downloaded
+                    Assert.Equal("out", modelInState.FileExtension);
                 }
 
 
@@ -125,6 +126,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     Assert.True(modelInState.Processed);
                     Assert.False(string.IsNullOrEmpty(modelInState.FilePath));
                     Assert.True(System.IO.File.Exists(modelInState.FilePath));
+                    Assert.EndsWith($"/files/{revision.FileId}/{revision.FileId}.out", modelInState.FilePath);
+                    Assert.Equal("out", modelInState.FileExtension);
                 }
 
                 var modelExternalIdV2 = $"{SeedData.TestModelExternalId}-2";
@@ -219,6 +222,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     Assert.False(modelInState.Processed);
                     Assert.False(string.IsNullOrEmpty(modelInState.FilePath));
                     Assert.True(System.IO.File.Exists(modelInState.FilePath));
+                    Assert.Equal("out", modelInState.FileExtension);
                     Assert.Equal(1, modelInState.DownloadAttempts);
 
                     Assert.False(modelInState.IsExtracted); // this is only true if the file was parsed locally
@@ -260,6 +264,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     Assert.True(modelInState.Processed);
                     Assert.False(string.IsNullOrEmpty(modelInState.FilePath));
                     Assert.True(System.IO.File.Exists(modelInState.FilePath));
+                    Assert.Equal("out", modelInState.FileExtension);
                     Assert.Equal(0, modelInState.DownloadAttempts); // This gets reset when the model is to set to be re-parsed
 
                     Assert.True(modelInState.IsExtracted); // this is only true if the file was parsed locally, which is the case here
@@ -319,6 +324,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                     Assert.True(modelInState.Processed);
                     Assert.False(string.IsNullOrEmpty(modelInState.FilePath));
                     Assert.True(System.IO.File.Exists(modelInState.FilePath));
+                    Assert.Equal("out", modelInState.FileExtension);
                 }
 
                 // delete current models

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
@@ -121,12 +121,13 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 foreach (var revision in revisions)
                 {
                     var modelInState = lib._state.GetValueOrDefault(revision.Id.ToString());
+                    var expectedPath = Path.Combine("files", revision.FileId.ToString(), $"{revision.FileId}.out");
                     Assert.NotNull(modelInState);
                     Assert.Equal(revision.ExternalId, modelInState.ExternalId);
                     Assert.True(modelInState.Processed);
                     Assert.False(string.IsNullOrEmpty(modelInState.FilePath));
                     Assert.True(System.IO.File.Exists(modelInState.FilePath));
-                    Assert.EndsWith($"/files/{revision.FileId}/{revision.FileId}.out", modelInState.FilePath);
+                    Assert.EndsWith(expectedPath, modelInState.FilePath);
                     Assert.Equal("out", modelInState.FileExtension);
                 }
 

--- a/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
@@ -283,6 +283,18 @@ namespace Cognite.Simulator.Tests.UtilsTests
             return OkItemsResponse(item);
         }
 
+        public static HttpResponseMessage MockFilesByIdsEndpoint()
+        {
+            var item = $@"{{
+                ""id"": 100,
+                ""name"": ""test_model.csv"",
+                ""mimeType"": ""text/csv"",
+                ""dataSetId"": 123,
+                ""uploaded"": true,
+            }}";
+            return OkItemsResponse(item);
+        }
+
         public static HttpResponseMessage MockFilesDownloadEndpoint(long size)
         {
             var response = new HttpResponseMessage() { Content = new ByteArrayContent([1]) };

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -592,10 +592,10 @@ namespace Cognite.Simulator.Utils
                     .DownloadAsync(new[] { fileId })
                     .ConfigureAwait(false);
 
-                if (file != null && downloadUriRes.Any() && downloadUriRes.First().DownloadUrl != null)
-                {
-                    var uri = downloadUriRes.First().DownloadUrl;
+                var downloadUri = downloadUriRes.FirstOrDefault()?.DownloadUrl;
 
+                if (file != null && downloadUri != null)
+                {
                     var fileExtension = file.GetExtension();
                     var storageFolder = Path.Combine(_modelFolder, $"{file.Id}");
                     var filename = Path.Combine(storageFolder, $"{file.Id}.{fileExtension}");
@@ -603,7 +603,7 @@ namespace Cognite.Simulator.Utils
                     modelState.IsInDirectory = true;
 
                     bool downloaded = await _downloadClient
-                        .DownloadFileAsync(uri, filename)
+                        .DownloadFileAsync(downloadUri, filename)
                         .ConfigureAwait(false);
                     if (downloaded)
                     {


### PR DESCRIPTION
Stacked on top of: https://github.com/cognitedata/dotnet-simulator-utils/pull/274 (more changes will follow)

Why:
This is both a logical improvement (paying the tech dept) but also an feature that unblocks our current inititive (support model external dependencies).

What:
So far we had been locking file extension to the "first item in the list of supported file extesions for a given simulator".


This has some major downsides:
1. Actual file extesion is completely ignored
3. Not possible to support multiple file extensions per simulator (needed soon for the new feature)

Changes:
1. do not call simulators API, rather take the extension from the name of the file (this is something we validate when user uploads the model)