### PR TITLE
feat(model-library): support multi-file model downloads and parsing

### DIFF
--- a/Cognite.Simulator.Tests/CdfTestClient.cs
+++ b/Cognite.Simulator.Tests/CdfTestClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -25,11 +26,9 @@ namespace Cognite.Simulator.Tests
 
     internal static class CdfTestClient
     {
-        private static int _configIdx;
-        private static string? _statePath;
-
         public static IServiceCollection AddCogniteTestClient(this IServiceCollection services, [CallerMemberName] string? testCallerName = null)
         {
+
             var host = Environment.GetEnvironmentVariable("COGNITE_HOST");
             var project = Environment.GetEnvironmentVariable("COGNITE_PROJECT");
             var tenant = Environment.GetEnvironmentVariable("AZURE_TENANT");
@@ -39,9 +38,6 @@ namespace Cognite.Simulator.Tests
             {
                 throw new NullReferenceException("Environment variables needed by tests cannot be read");
             }
-
-            var index = Interlocked.Increment(ref _configIdx);
-            _statePath = testCallerName != null ? $"test-state-{testCallerName}" : $"test-state-{index}";
 
             var authConfig = new AuthenticatorConfig
             {
@@ -71,10 +67,14 @@ namespace Cognite.Simulator.Tests
                 }
             };
 
+            var uniqueId = Guid.NewGuid().ToString("N").Substring(0, 4);
+            var testNameStr = testCallerName != null ? $"-{testCallerName}" : "";
+            var statePath = $"test-state{testNameStr}-{uniqueId}";
+
             var stateStoreConfig = new StateStoreConfig
             {
                 Database = StateStoreConfig.StorageType.LiteDb,
-                Location = _statePath
+                Location = statePath
             };
 
             // Configure logging

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
@@ -33,7 +33,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             new SimpleRequestMocker(uri => uri.EndsWith("/simulators/list") || uri.EndsWith("/simulators") || uri.EndsWith("/simulators/update"), MockSimulatorsEndpoint),
             new SimpleRequestMocker(uri => uri.Contains("/simulators/integrations"), MockSimulatorsIntegrationsEndpoint),
             new SimpleRequestMocker(uri => uri.Contains("/simulators/routines/revisions/list"), MockSimulatorRoutineRevEndpoint, 1),
-            new SimpleRequestMocker(uri => true, () => GoneResponse)
+            new SimpleRequestMocker(uri => true, GoneResponse)
         };
 
         // We need to mock the HttpClientFactory to return the mocked responses

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -127,8 +127,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
 
             VerifyLog(mockedLogger, LogLevel.Debug, "Model revision not found locally, adding to the local state: TestModelExternalId-v1", Times.Exactly(1), true);
-            VerifyLog(mockedLogger, LogLevel.Information, "Downloading files for model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
-            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (0/1): 100. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading 1 file(s) for model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (1/1): 100. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
             VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 100. Model revision: TestModelExternalId-v1", Times.Exactly(1), true);
         }
 

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -127,7 +127,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
 
             VerifyLog(mockedLogger, LogLevel.Debug, "Model revision not found locally, adding to the local state: TestModelExternalId-v1", Times.Exactly(1), true);
-            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file: 100. Model revision external id: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading files for model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (0/1): 100. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
             VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 100. Model revision: TestModelExternalId-v1", Times.Exactly(1), true);
         }
 

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -26,6 +26,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
     /// Tests for the ModelLibraryBase class with focus on the concurrency aspects.
     /// Uses FakeModelLibrary and SimpleRequestMocker to mock the HTTP layer.
     /// </summary>
+    [Collection(nameof(SequentialTestCollection))]
     public class ModelLibraryConcurrencyTest : IDisposable
     {
         private StateStoreConfig? stateConfig;
@@ -40,7 +41,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
             new SimpleRequestMocker(uri => uri.Contains("/files/downloadlink"), MockFilesDownloadLinkEndpoint, 1),
             new SimpleRequestMocker(uri => uri.Contains("/files/download"), () => MockFilesDownloadEndpoint(1), 1),
-            new SimpleRequestMocker(uri => true, () => GoneResponse).ShouldBeCalled(Times.AtMost(100)) // doesn't matter for the test
+            new SimpleRequestMocker(uri => true, GoneResponse).ShouldBeCalled(Times.AtMost(100)) // doesn't matter for the test
         };
 
         public void Dispose()

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExtDepsUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExtDepsUnitTest.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Cognite.Extractor.StateStorage;
+using Cognite.Simulator.Utils;
+using Cognite.Simulator.Utils.Automation;
+
+using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
+using static Cognite.Simulator.Tests.UtilsTests.TestUtilities;
+
+namespace Cognite.Simulator.Tests.UtilsTests
+{
+    /// <summary>
+    /// Tests for the DefaultModelLibrary class that focus on the concurrency aspects.
+    /// Uses SimpleRequestMocker to mock the HTTP layer.
+    /// </summary>
+    public class ModelLibraryExtDepsTest
+    {
+
+        public static HttpResponseMessage MockFilesByIdsEndpoint()
+        {
+            var fileInfos = new[]
+            {
+            new { id = 100, name = "test_model.csv", mimeType = "text/csv" },
+            new { id = 101, name = "test_model_dep1.csv", mimeType = "text/xml" },
+            new { id = 102, name = "test_model_dep2.csv", mimeType = "text/xml" }
+            };
+
+            var items = string.Join(",\n", fileInfos.Select(f => $@"{{
+                ""id"": {f.id},
+                ""name"": ""{f.name}"",
+                ""mimeType"": ""{f.mimeType}"",
+                ""dataSetId"": 123,
+                ""uploaded"": true
+            }}"));
+
+            return OkItemsResponse(items);
+        }
+
+
+        private static HttpResponseMessage MockSimulatorModelRevEndpoint()
+        {
+            var externalDependencies = Enumerable.Range(1, 2)
+                .Select(i => $@"{{
+                    ""file"": {{ ""id"": {100 + i} }},
+                    ""arguments"": {{ ""address"": ""test.address.{i}"" }}
+                }}").ToList();
+
+            var item = $@"{{
+                ""id"": 1234567890,
+                ""externalId"": ""TestModelExternalId-v1"",
+                ""name"": ""Test Model Revision"",
+                ""description"": ""Test model revision description"",
+                ""simulatorExternalId"": ""{SeedData.TestSimulatorExternalId}"",
+                ""modelExternalId"": ""TestModelExternalId"",
+                ""externalDependencies"": [
+                    {string.Join(",", externalDependencies)}
+                ],
+                ""fileId"": 100,
+                ""createdByUserId"": ""n/a"",
+                ""status"": ""unknown"",
+                ""dataSetId"": 123,
+                ""versionNumber"": 1,
+                ""logId"": 1234567890,
+                ""createdTime"": 1234567890000,
+                ""lastUpdatedTime"": 1234567890000
+            }}";
+            return OkItemsResponse(item);
+        }
+
+        private static readonly IList<SimpleRequestMocker> endpointMockTemplates = new List<SimpleRequestMocker>
+        {
+            new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
+            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), () => OkItemsResponse(""), 1), // Returns empty to simulate no revisions found on first call
+            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint, 5),
+            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/update"), MockSimulatorModelRevEndpoint, 1),
+            new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
+            new SimpleRequestMocker(uri => uri.Contains("/files/downloadlink"), MockFilesDownloadLinkEndpoint, 3),
+            new SimpleRequestMocker(uri => uri.Contains("/files/download"), () => MockFilesDownloadEndpoint(1), 3),
+            new SimpleRequestMocker(uri => true, () => GoneResponse)
+        };
+
+        /// <summary>
+        /// This test verifies that multiple concurrent calls to GetModelRevision for the same model
+        /// don't result in parallel processing of the same model revision.
+        /// </summary>
+        [Fact]
+        public async Task TestModelLibraryWithExternalDependencies()
+        {
+            try
+            {
+                var httpMocks = GetMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
+                var mockedLogger = new Mock<ILogger<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>>();
+                var mockedSimulatorClient = new Mock<ISimulatorClient<DefaultModelFilestate, SimulatorRoutineRevision>>();
+                mockedSimulatorClient.Setup(client => client.ExtractModelInformation(It.IsAny<DefaultModelFilestate>(), It.IsAny<CancellationToken>()))
+                    .Returns((DefaultModelFilestate state, CancellationToken token) =>
+                    {
+                        state.ParsingInfo.SetSuccess();
+                        return Task.CompletedTask;
+                    });
+
+                var services = new ServiceCollection();
+                services.AddSingleton(httpMocks.factory.Object);
+                services.AddCogniteTestClient();
+                services.AddSingleton(mockedLogger.Object);
+                services.AddSingleton(mockedSimulatorClient.Object);
+                services.AddSingleton<FileStorageClient>();
+                services.AddSingleton<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
+                services.AddSingleton(SeedData.SimulatorCreate);
+
+                var config = new DefaultConfig<AutomationConfig>();
+                config.GenerateDefaults();
+                services.AddSingleton(config);
+
+                using var provider = services.BuildServiceProvider();
+
+                var stateConfig = provider.GetRequiredService<StateStoreConfig>();
+                using var source = new CancellationTokenSource();
+                var lib = provider.GetRequiredService<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
+                await lib.Init(source.Token);
+                Assert.Empty(lib._state);
+
+                var modelInState = await lib.GetModelRevision("TestModelExternalId-v1");
+
+                Assert.NotNull(modelInState);
+
+                // Basic validations
+                Assert.NotEmpty(lib._state);
+                Assert.NotNull(modelInState);
+                Assert.Equal(100, modelInState.CdfId);
+                Assert.Equal(123, modelInState.DataSetId);
+                Assert.Equal("TestModelExternalId-v1", modelInState.ExternalId);
+                Assert.Equal("TestModelExternalId", modelInState.ModelExternalId);
+                Assert.Equal(1234567890000, modelInState.CreatedTime);
+                Assert.Equal(1, modelInState.DownloadAttempts);
+                Assert.Equal(SimulatorModelRevisionStatus.success, modelInState.ParsingInfo.Status);
+                Assert.True(modelInState.CanRead);
+                Assert.False(modelInState.ParsingInfo.Error);
+                Assert.True(modelInState.ParsingInfo.Parsed);
+                Assert.EndsWith(Path.Combine("100", "100.csv"), modelInState.FilePath);
+                Assert.Equal("csv", modelInState.FileExtension);
+                Assert.True(modelInState.Downloaded);
+
+                File.Exists(Path.Combine("100", "100.csv"));
+                File.Exists(Path.Combine("101", "101.xml"));
+                File.Exists(Path.Combine("102", "102.xml"));
+
+                foreach (var mocker in endpointMockTemplates)
+                {
+                    mocker.AssertCallCount();
+                }
+
+                VerifyLog(mockedLogger, LogLevel.Debug, "Model revision not found locally, adding to the local state: TestModelExternalId-v1", Times.Exactly(1), true);
+                VerifyLog(mockedLogger, LogLevel.Information, "Downloading 3 file(s) for model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+                VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (1/3): 100. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+                VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (2/3): 101. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+                VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (3/3): 102. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+                VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 100. Model revision: TestModelExternalId-v1", Times.Exactly(1), true);
+            }
+            finally
+            {
+                CleanUpFiles(true, null);
+            }
+        }
+    }
+}

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExtDepsUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExtDepsUnitTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -23,19 +24,23 @@ using static Cognite.Simulator.Tests.UtilsTests.TestUtilities;
 namespace Cognite.Simulator.Tests.UtilsTests
 {
     /// <summary>
-    /// Tests for the DefaultModelLibrary class that focus on the concurrency aspects.
+    /// Tests for the DefaultModelLibrary class with focus on external dependencies. 
     /// Uses SimpleRequestMocker to mock the HTTP layer.
     /// </summary>
-    public class ModelLibraryExtDepsTest
+    public class ModelLibraryExtDepsTest : IDisposable
     {
+        public void Dispose()
+        {
+            CleanUpFiles(true, null);
+        }
 
         public static HttpResponseMessage MockFilesByIdsEndpoint()
         {
             var fileInfos = new[]
             {
             new { id = 100, name = "test_model.csv", mimeType = "text/csv" },
-            new { id = 101, name = "test_model_dep1.csv", mimeType = "text/xml" },
-            new { id = 102, name = "test_model_dep2.csv", mimeType = "text/xml" }
+            new { id = 101, name = "test_model_dep1.xml", mimeType = "text/xml" },
+            new { id = 102, name = "test_model_dep2.xml", mimeType = "text/xml" }
             };
 
             var items = string.Join(",\n", fileInfos.Select(f => $@"{{
@@ -83,7 +88,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
         private static readonly IList<SimpleRequestMocker> endpointMockTemplates = new List<SimpleRequestMocker>
         {
             new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
-            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), () => OkItemsResponse(""), 1), // Returns empty to simulate no revisions found on first call
+            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), () => MockSimulatorModelRevEndpoint(), 1),
             new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint, 5),
             new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/update"), MockSimulatorModelRevEndpoint, 1),
             new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
@@ -99,80 +104,88 @@ namespace Cognite.Simulator.Tests.UtilsTests
         [Fact]
         public async Task TestModelLibraryWithExternalDependencies()
         {
-            try
-            {
-                var httpMocks = GetMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
-                var mockedLogger = new Mock<ILogger<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>>();
-                var mockedSimulatorClient = new Mock<ISimulatorClient<DefaultModelFilestate, SimulatorRoutineRevision>>();
-                mockedSimulatorClient.Setup(client => client.ExtractModelInformation(It.IsAny<DefaultModelFilestate>(), It.IsAny<CancellationToken>()))
-                    .Returns((DefaultModelFilestate state, CancellationToken token) =>
-                    {
-                        state.ParsingInfo.SetSuccess();
-                        return Task.CompletedTask;
-                    });
-
-                var services = new ServiceCollection();
-                services.AddSingleton(httpMocks.factory.Object);
-                services.AddCogniteTestClient();
-                services.AddSingleton(mockedLogger.Object);
-                services.AddSingleton(mockedSimulatorClient.Object);
-                services.AddSingleton<FileStorageClient>();
-                services.AddSingleton<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
-                services.AddSingleton(SeedData.SimulatorCreate);
-
-                var config = new DefaultConfig<AutomationConfig>();
-                config.GenerateDefaults();
-                services.AddSingleton(config);
-
-                using var provider = services.BuildServiceProvider();
-
-                var stateConfig = provider.GetRequiredService<StateStoreConfig>();
-                using var source = new CancellationTokenSource();
-                var lib = provider.GetRequiredService<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
-                await lib.Init(source.Token);
-                Assert.Empty(lib._state);
-
-                var modelInState = await lib.GetModelRevision("TestModelExternalId-v1");
-
-                Assert.NotNull(modelInState);
-
-                // Basic validations
-                Assert.NotEmpty(lib._state);
-                Assert.NotNull(modelInState);
-                Assert.Equal(100, modelInState.CdfId);
-                Assert.Equal(123, modelInState.DataSetId);
-                Assert.Equal("TestModelExternalId-v1", modelInState.ExternalId);
-                Assert.Equal("TestModelExternalId", modelInState.ModelExternalId);
-                Assert.Equal(1234567890000, modelInState.CreatedTime);
-                Assert.Equal(1, modelInState.DownloadAttempts);
-                Assert.Equal(SimulatorModelRevisionStatus.success, modelInState.ParsingInfo.Status);
-                Assert.True(modelInState.CanRead);
-                Assert.False(modelInState.ParsingInfo.Error);
-                Assert.True(modelInState.ParsingInfo.Parsed);
-                Assert.EndsWith(Path.Combine("100", "100.csv"), modelInState.FilePath);
-                Assert.Equal("csv", modelInState.FileExtension);
-                Assert.True(modelInState.Downloaded);
-
-                File.Exists(Path.Combine("100", "100.csv"));
-                File.Exists(Path.Combine("101", "101.xml"));
-                File.Exists(Path.Combine("102", "102.xml"));
-
-                foreach (var mocker in endpointMockTemplates)
+            var httpMocks = GetMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
+            var mockedLogger = new Mock<ILogger<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>>();
+            var mockedSimulatorClient = new Mock<ISimulatorClient<DefaultModelFilestate, SimulatorRoutineRevision>>();
+            mockedSimulatorClient.Setup(client => client.ExtractModelInformation(It.IsAny<DefaultModelFilestate>(), It.IsAny<CancellationToken>()))
+                .Returns((DefaultModelFilestate state, CancellationToken token) =>
                 {
-                    mocker.AssertCallCount();
-                }
+                    state.ParsingInfo.SetSuccess();
+                    return Task.CompletedTask;
+                });
 
-                VerifyLog(mockedLogger, LogLevel.Debug, "Model revision not found locally, adding to the local state: TestModelExternalId-v1", Times.Exactly(1), true);
-                VerifyLog(mockedLogger, LogLevel.Information, "Downloading 3 file(s) for model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
-                VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (1/3): 100. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
-                VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (2/3): 101. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
-                VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (3/3): 102. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
-                VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 100. Model revision: TestModelExternalId-v1", Times.Exactly(1), true);
-            }
-            finally
+            var services = new ServiceCollection();
+            services.AddSingleton(httpMocks.factory.Object);
+            services.AddCogniteTestClient();
+            services.AddSingleton(mockedLogger.Object);
+            services.AddSingleton(mockedSimulatorClient.Object);
+            services.AddSingleton<FileStorageClient>();
+            services.AddSingleton<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
+            services.AddSingleton(SeedData.SimulatorCreate);
+
+            var config = new DefaultConfig<AutomationConfig>();
+            config.GenerateDefaults();
+            services.AddSingleton(config);
+
+            using var provider = services.BuildServiceProvider();
+
+            var stateConfig = provider.GetRequiredService<StateStoreConfig>();
+            var lib = provider.GetRequiredService<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
+            await lib.Init(CancellationToken.None);
+            Assert.NotEmpty(lib._state);
+
+            var modelInState = await lib.GetModelRevision("TestModelExternalId-v1");
+
+            Assert.NotNull(modelInState);
+
+            // Basic validations
+            Assert.NotEmpty(lib._state);
+            Assert.NotNull(modelInState);
+            Assert.Equal(123, modelInState.DataSetId);
+            Assert.Equal("TestModelExternalId-v1", modelInState.ExternalId);
+            Assert.Equal(1, modelInState.DownloadAttempts);
+            Assert.True(modelInState.ParsingInfo.Parsed);
+            Assert.EndsWith(Path.Combine("100", "100.csv"), modelInState.FilePath);
+            Assert.Equal("csv", modelInState.FileExtension);
+            Assert.True(modelInState.Downloaded);
+
+            File.Exists(Path.Combine("100", "100.csv"));
+            File.Exists(Path.Combine("101", "101.xml"));
+            File.Exists(Path.Combine("102", "102.xml"));
+
+            Assert.NotNull(modelInState.DependencyFiles);
+            Assert.Equal(2, modelInState.DependencyFiles.Count);
+
+            var expectedDependencyFiles = Enumerable.Range(1, 2)
+                .Select(i => new DependencyFile
+                {
+                    Id = 100 + i,
+                    FilePath = Path.GetFullPath(Path.Combine($"files/{100 + i}", $"{100 + i}.xml")),
+                    Arguments = new Dictionary<string, string> { { "address", "test.address." + i } }
+                })
+                .ToArray();
+            Assert.Equivalent(expectedDependencyFiles, modelInState.DependencyFiles);
+
+            foreach (var mocker in endpointMockTemplates)
             {
-                CleanUpFiles(true, null);
+                mocker.AssertCallCount();
             }
+
+            VerifyLog(mockedLogger, LogLevel.Debug, "Model revision not found locally, adding to the local state: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading 3 file(s) for model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (1/3): 100. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (2/3): 101. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (3/3): 102. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 100. Model revision: TestModelExternalId-v1", Times.Exactly(1), true);
+
+            // clear the state, run Init to load from the store to check the deserialization from LiteDB
+            modelInState.DependencyFiles.Clear();
+            Assert.NotNull(modelInState);
+            Assert.Empty(modelInState.DependencyFiles);
+            await lib.Init(CancellationToken.None);
+
+            Assert.NotNull(modelInState);
+            Assert.Equivalent(expectedDependencyFiles, modelInState.DependencyFiles);
         }
     }
 }

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExtDepsUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExtDepsUnitTest.cs
@@ -91,7 +91,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
         private static readonly IList<SimpleRequestMocker> endpointMockTemplates = new List<SimpleRequestMocker>
         {
             new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
-            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), () => MockSimulatorModelRevEndpoint(), 1),
+            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), MockSimulatorModelRevEndpoint, 1),
             new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint, 5),
             new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/update"), MockSimulatorModelRevEndpoint, 1),
             new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
@@ -140,9 +140,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             Assert.NotNull(modelInState);
 
             // Basic validations
-            Assert.NotEmpty(lib._state);
             Assert.NotNull(modelInState);
-            Assert.Equal(123, modelInState.DataSetId);
             Assert.Equal("TestModelExternalId-v1", modelInState.ExternalId);
             Assert.Equal(1, modelInState.DownloadAttempts);
             Assert.True(modelInState.ParsingInfo.Parsed);
@@ -188,7 +186,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
             Assert.NotNull(modelInState);
             Assert.Equivalent(expectedDependencyFiles, modelInState.DependencyFiles);
-
         }
     }
 }

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
@@ -211,7 +211,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var endpointMockTemplates = new List<SimpleRequestMocker>
             {
                 new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
-                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), () => OkItemsResponse(""), 1), // first call returns empty
+                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), () => OkItemsResponse(""), 1),
                 new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint, 5),
                 new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
                 new SimpleRequestMocker(uri => uri.Contains("/files/downloadlink"), MockFilesDownloadLinkEndpoint, 3),
@@ -231,7 +231,6 @@ namespace Cognite.Simulator.Tests.UtilsTests
             // Assert
             Assert.NotNull(modelInState);
             Assert.Equal("TestModelExternalId-v1", modelInState.ExternalId);
-            Assert.Equal(1, modelInState.DownloadAttempts);
             Assert.NotNull(modelInState.FilePath);
             Assert.False(modelInState.ParsingInfo.Parsed);
             Assert.False(modelInState.Downloaded); // not all files were downloaded successfully
@@ -258,11 +257,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 mocker.AssertCallCount();
             }
 
-            VerifyLog(mockedLogger, LogLevel.Debug, "Model revision not found locally, adding to the local state: TestModelExternalId-v1", Times.Exactly(1), true);
             VerifyLog(mockedLogger, LogLevel.Information, "Downloading 3 file(s) for model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
-            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (1/3): 100. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
-            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (2/3): 101. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
-            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (3/3): 102. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
             VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 100. Model revision: TestModelExternalId-v1", Times.Exactly(1), true);
             VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 102. Model revision: TestModelExternalId-v1", Times.Exactly(1), true);
             VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 101. Model revision: TestModelExternalId-v1", Times.Never(), true);

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,7 +29,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
     /// Uses SimpleRequestMocker to mock the HTTP layer.
     /// </summary>
     [Collection(nameof(SequentialTestCollection))]
-    public class ModelLibraryExtDepsTest : IDisposable
+    public class ModelLibraryExtertnalDepsTest : IDisposable
     {
         StateStoreConfig? stateConfig;
         ModelLibraryConfig? modelLibraryConfig;
@@ -88,25 +89,11 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }}";
             return OkItemsResponse(item);
         }
-        private static readonly IList<SimpleRequestMocker> endpointMockTemplates = new List<SimpleRequestMocker>
-        {
-            new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
-            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), MockSimulatorModelRevEndpoint, 1),
-            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint, 5),
-            new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/update"), MockSimulatorModelRevEndpoint, 1),
-            new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
-            new SimpleRequestMocker(uri => uri.Contains("/files/downloadlink"), MockFilesDownloadLinkEndpoint, 3),
-            new SimpleRequestMocker(uri => uri.Contains("/files/download"), () => MockFilesDownloadEndpoint(1), 3),
-            new SimpleRequestMocker(uri => true, GoneResponse).ShouldBeCalled(Times.AtMost(100)) // doesn't matter for the test
-        };
 
-
-        /// <summary>
-        /// This test verifies that the ModelLibrary can handle external dependencies correctly.
-        /// It checks that the model revision is fetched, files are downloaded, and model is processed correctly.
-        /// </summary>
-        [Fact]
-        public async Task TestModelLibraryWithExternalDependencies()
+        private (
+            DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>,
+            Mock<ILogger<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>>
+            ) SetupServices(List<SimpleRequestMocker> endpointMockTemplates, [CallerMemberName] string? testCallerName = null)
         {
             var mockedLogger = new Mock<ILogger<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>>();
             var mockedSimulatorClient = new Mock<ISimulatorClient<DefaultModelFilestate, SimulatorRoutineRevision>>();
@@ -120,26 +107,51 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var services = new ServiceCollection();
             services.AddMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
             services.AddSingleton(mockedLogger.Object);
-            services.AddCogniteTestClient();
+            services.AddCogniteTestClient(testCallerName);
             services.AddSingleton(mockedSimulatorClient.Object);
             services.AddSingleton<FileStorageClient>();
             services.AddSingleton<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
             services.AddSingleton(SeedData.SimulatorCreate);
             services.AddDefaultConfig();
 
-            using var provider = services.BuildServiceProvider();
+            var provider = services.BuildServiceProvider();
 
             stateConfig = provider.GetRequiredService<StateStoreConfig>();
             modelLibraryConfig = provider.GetRequiredService<DefaultConfig<AutomationConfig>>().Connector.ModelLibrary;
             var lib = provider.GetRequiredService<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
+
+            return (lib, mockedLogger);
+        }
+
+        /// <summary>
+        /// This test verifies that the ModelLibrary can handle external dependencies correctly.
+        /// It checks that the model revision is fetched, files are downloaded, and model is processed correctly.
+        /// </summary>
+        [Fact]
+        public async Task TestModelLibraryWithExternalDependencies()
+        {
+            // Arrange
+            var endpointMockTemplates = new List<SimpleRequestMocker>
+            {
+                new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
+                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), MockSimulatorModelRevEndpoint, 1),
+                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint, 5),
+                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/update"), MockSimulatorModelRevEndpoint, 1),
+                new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
+                new SimpleRequestMocker(uri => uri.Contains("/files/downloadlink"), MockFilesDownloadLinkEndpoint, 3),
+                new SimpleRequestMocker(uri => uri.Contains("/files/download"), () => MockFilesDownloadEndpoint(1), 3),
+                new SimpleRequestMocker(uri => true, GoneResponse).ShouldBeCalled(Times.AtMost(100)) // doesn't matter for the test
+            };
+
+            var (lib, mockedLogger) = SetupServices(endpointMockTemplates);
+
             await lib.Init(CancellationToken.None);
             Assert.NotEmpty(lib._state);
 
+            // Act
             var modelInState = await lib.GetModelRevision("TestModelExternalId-v1");
 
-            Assert.NotNull(modelInState);
-
-            // Basic validations
+            // Assert
             Assert.NotNull(modelInState);
             Assert.Equal("TestModelExternalId-v1", modelInState.ExternalId);
             Assert.Equal(1, modelInState.DownloadAttempts);
@@ -148,9 +160,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
             Assert.Equal("csv", modelInState.FileExtension);
             Assert.True(modelInState.Downloaded);
 
-            File.Exists(Path.Combine("100", "100.csv"));
-            File.Exists(Path.Combine("101", "101.xml"));
-            File.Exists(Path.Combine("102", "102.xml"));
+            var filesDirectory = Path.GetFullPath(modelLibraryConfig?.FilesDirectory ?? string.Empty);
+            Assert.True(File.Exists(Path.Combine(filesDirectory, "100", "100.csv")));
+            Assert.True(File.Exists(Path.Combine(filesDirectory, "101", "101.xml")));
+            Assert.True(File.Exists(Path.Combine(filesDirectory, "102", "102.xml")));
 
             Assert.NotNull(modelInState.DependencyFiles);
             Assert.Equal(2, modelInState.DependencyFiles.Count);
@@ -159,8 +172,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 .Select(i => new DependencyFile
                 {
                     Id = 100 + i,
-                    FilePath = Path.GetFullPath(Path.Combine($"{modelLibraryConfig.FilesDirectory}/{100 + i}", $"{100 + i}.xml")),
-                    Arguments = new Dictionary<string, string> { { "address", "test.address." + i } }
+                    FilePath = Path.Combine(filesDirectory, $"{100 + i}", $"{100 + i}.xml"),
+                    Arguments = new() { { "address", "test.address." + i } }
                 })
                 .ToArray();
             Assert.Equivalent(expectedDependencyFiles, modelInState.DependencyFiles);
@@ -186,6 +199,73 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
             Assert.NotNull(modelInState);
             Assert.Equivalent(expectedDependencyFiles, modelInState.DependencyFiles);
+        }
+
+        /// <summary>
+        /// This test verifies that the ModelLibrary handles single file downloads with external dependencies correctly.
+        /// </summary>
+        [Fact]
+        public async Task TestModelLibraryWithExternalDependenciesLoadFailure()
+        {
+            // Arrange
+            var endpointMockTemplates = new List<SimpleRequestMocker>
+            {
+                new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
+                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), () => OkItemsResponse(""), 1), // first call returns empty
+                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint, 5),
+                new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
+                new SimpleRequestMocker(uri => uri.Contains("/files/downloadlink"), MockFilesDownloadLinkEndpoint, 3),
+                new SimpleRequestMocker(uri => uri.Contains("/files/download"), () => MockFilesDownloadEndpoint(1), 1),
+                new SimpleRequestMocker(uri => uri.Contains("/files/download"), GoneResponse, 1), // one file download fails
+                new SimpleRequestMocker(uri => uri.Contains("/files/download"), () => MockFilesDownloadEndpoint(1), 1),
+                new SimpleRequestMocker(uri => true, GoneResponse).ShouldBeCalled(Times.AtMost(100)) // doesn't matter for the test
+            };
+
+            var (lib, mockedLogger) = SetupServices(endpointMockTemplates);
+            await lib.Init(CancellationToken.None);
+            Assert.Empty(lib._state);
+
+            // Act
+            var modelInState = await lib.GetModelRevision("TestModelExternalId-v1");
+
+            // Assert
+            Assert.NotNull(modelInState);
+            Assert.Equal("TestModelExternalId-v1", modelInState.ExternalId);
+            Assert.Equal(1, modelInState.DownloadAttempts);
+            Assert.NotNull(modelInState.FilePath);
+            Assert.False(modelInState.ParsingInfo.Parsed);
+            Assert.False(modelInState.Downloaded); // not all files were downloaded successfully
+
+            var filesDirectory = Path.GetFullPath(modelLibraryConfig?.FilesDirectory ?? string.Empty);
+            Assert.True(File.Exists(Path.Combine(filesDirectory, "100", "100.csv")));
+            Assert.False(File.Exists(Path.Combine(filesDirectory, "101", "101.xml"))); // this file download failed
+            Assert.True(File.Exists(Path.Combine(filesDirectory, "102", "102.xml")));
+
+            Assert.Equal(2, modelInState.DependencyFiles.Count);
+
+            var expectedDependencyFiles = Enumerable.Range(1, 2)
+                .Select(i => new DependencyFile
+                {
+                    Id = 100 + i,
+                    FilePath = i == 1 ? null : Path.Combine(filesDirectory, $"{100 + i}", $"{100 + i}.xml"),
+                    Arguments = new() { { "address", "test.address." + i } }
+                })
+                .ToArray();
+            Assert.Equivalent(expectedDependencyFiles, modelInState.DependencyFiles);
+
+            foreach (var mocker in endpointMockTemplates)
+            {
+                mocker.AssertCallCount();
+            }
+
+            VerifyLog(mockedLogger, LogLevel.Debug, "Model revision not found locally, adding to the local state: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading 3 file(s) for model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (1/3): 100. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (2/3): 101. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Information, "Downloading file (3/3): 102. Model revision external ID: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 100. Model revision: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 102. Model revision: TestModelExternalId-v1", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Debug, "File downloaded: 101. Model revision: TestModelExternalId-v1", Times.Never(), true);
         }
     }
 }

--- a/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
@@ -116,8 +116,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
             File.WriteAllText(filePath, yamlContent);
         }
 
-        public static HttpResponseMessage GoneResponse =
-            CreateResponse(HttpStatusCode.Gone, "{\"error\": {\"code\": 410,\"message\": \"Gone\"}}");
+        public static HttpResponseMessage GoneResponse()
+        {
+            return CreateResponse(HttpStatusCode.Gone, "{\"error\": {\"code\": 410,\"message\": \"Gone\"}}");
+        }
 
         /// <summary>
         /// Mocks the requests to the endpoints with the given templates.

--- a/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
@@ -116,10 +116,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             File.WriteAllText(filePath, yamlContent);
         }
 
-        public static HttpResponseMessage GoneResponse()
-        {
-            return CreateResponse(HttpStatusCode.Gone, "{\"error\": {\"code\": 410,\"message\": \"Gone\"}}");
-        }
+        public static HttpResponseMessage GoneResponse() => CreateResponse(HttpStatusCode.Gone, "{\"error\": {\"code\": 410,\"message\": \"Gone\"}}");
 
         /// <summary>
         /// Mocks the requests to the endpoints with the given templates.

--- a/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
@@ -358,6 +358,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 if (stateConfig != null)
                 {
                     StateUtils.DeleteLocalFile(stateConfig.Location);
+                    StateUtils.DeleteLocalFile(stateConfig.Location + "-log");
                 }
             }
             catch (Exception ex)

--- a/Cognite.Simulator.Utils/DefaultClasses/DefaultModelLibrary.cs
+++ b/Cognite.Simulator.Utils/DefaultClasses/DefaultModelLibrary.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -81,6 +82,8 @@ namespace Cognite.Simulator.Utils
             {
                 throw new ArgumentNullException(nameof(modelRevision));
             }
+            var dependencyFiles = modelRevision.ExternalDependencies != null ?
+                modelRevision.ExternalDependencies.Select(dependency => new DependencyFile(dependency)).ToList() : null;
             var output = new TModelStateBase
             {
                 Id = modelRevision.Id.ToString(),
@@ -91,6 +94,7 @@ namespace Cognite.Simulator.Utils
                 CreatedTime = modelRevision.CreatedTime,
                 CdfId = modelRevision.FileId,
                 LogId = modelRevision.LogId,
+                DependencyFiles = dependencyFiles,
                 Version = modelRevision.VersionNumber,
                 ExternalId = modelRevision.ExternalId,
             };

--- a/Cognite.Simulator.Utils/DefaultClasses/DefaultModelLibrary.cs
+++ b/Cognite.Simulator.Utils/DefaultClasses/DefaultModelLibrary.cs
@@ -83,7 +83,7 @@ namespace Cognite.Simulator.Utils
                 throw new ArgumentNullException(nameof(modelRevision));
             }
             var dependencyFiles = modelRevision.ExternalDependencies != null ?
-                modelRevision.ExternalDependencies.Select(dependency => new DependencyFile(dependency)).ToList() : null;
+                modelRevision.ExternalDependencies.Select(dependency => new DependencyFile(dependency)).ToList() : [];
             var output = new TModelStateBase
             {
                 Id = modelRevision.Id.ToString(),

--- a/Cognite.Simulator.Utils/FileState.cs
+++ b/Cognite.Simulator.Utils/FileState.cs
@@ -233,7 +233,7 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         public List<DependencyFile> DependencyFiles
         {
-            get => _dependencyFiles;
+            get => _dependencyFiles ??= new List<DependencyFile>();
             set
             {
                 if (value == _dependencyFiles) return;

--- a/Cognite.Simulator.Utils/FileState.cs
+++ b/Cognite.Simulator.Utils/FileState.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 using Cognite.Extractor.StateStorage;
-using Cognite.Simulator.Extensions;
 
 using CogniteSdk.Alpha;
 
@@ -113,23 +111,6 @@ namespace Cognite.Simulator.Utils
             }
         }
 
-        private List<DependencyFile> _dependencyFiles;
-
-        /// <summary>
-        /// List of dependency files that the main model file requires to function correctly.
-        /// Each dependency file has a unique identifier, a path on disk, and arguments providing additional metadata about how the file should be used in the model.
-        /// Only used by simulators that work with multi-file models.
-        /// </summary>
-        public List<DependencyFile> DependencyFiles
-        {
-            get => _dependencyFiles;
-            set
-            {
-                if (value == _dependencyFiles) return;
-                LastTimeModified = DateTime.UtcNow;
-                _dependencyFiles = value;
-            }
-        }
 
         private string _filePath;
 
@@ -244,6 +225,24 @@ namespace Cognite.Simulator.Utils
             }
         }
 
+        private List<DependencyFile> _dependencyFiles;
+
+        /// <summary>
+        /// List of dependency files that the main model file requires to function correctly.
+        /// Each dependency file has a unique identifier, a path on disk, and arguments providing additional metadata about how the file should be used in the model.
+        /// Only used by simulators that work with multi-file models.
+        /// </summary>
+        public List<DependencyFile> DependencyFiles
+        {
+            get => _dependencyFiles;
+            set
+            {
+                if (value == _dependencyFiles) return;
+                LastTimeModified = DateTime.UtcNow;
+                _dependencyFiles = value;
+            }
+        }
+
         private int _downloadAttempts;
 
         /// <summary>
@@ -280,9 +279,9 @@ namespace Cognite.Simulator.Utils
             _externalId = poco.ExternalId;
             _logId = poco.LogId;
             _fileExtension = poco.FileExtension;
+            _dependencyFiles = poco.DependencyFiles;
             _downloadAttempts = poco.DownloadAttempts;
             _version = poco.Version;
-
         }
 
         /// <summary>
@@ -305,6 +304,7 @@ namespace Cognite.Simulator.Utils
                 ExternalId = ExternalId,
                 LogId = LogId,
                 FileExtension = FileExtension,
+                DependencyFiles = DependencyFiles,
                 DownloadAttempts = DownloadAttempts,
                 Version = Version
             };
@@ -331,6 +331,13 @@ namespace Cognite.Simulator.Utils
         /// The absolute path where the dependency file is stored on disk
         /// </summary>
         public string FilePath { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DependencyFile"/> class.
+        /// </summary>
+        public DependencyFile()
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DependencyFile"/> class.
@@ -389,14 +396,6 @@ namespace Cognite.Simulator.Utils
         public long? DataSetId { get; set; }
 
         /// <summary>
-        /// List of dependency files that the main model file requires to function correctly.
-        /// Each dependency file has a unique identifier, a path on disk, and optional
-        /// arguments providing additional metadata about how the file should be used.
-        /// </summary>
-        [StateStoreProperty("dependency-files")]
-        public List<DependencyFile> DependencyFiles { get; set; } = new List<DependencyFile>();
-
-        /// <summary>
         /// Path to the file in the local disk
         /// </summary>
         [StateStoreProperty("file-path")]
@@ -431,6 +430,14 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         [StateStoreProperty("log-id")]
         public long LogId { get; set; }
+
+        /// <summary>
+        /// List of dependency files that the main model file requires to function correctly.
+        /// Each dependency file has a unique identifier, a path on disk, and optional
+        /// arguments providing additional metadata about how the file should be used.
+        /// </summary>
+        [StateStoreProperty("dependency-files")]
+        public List<DependencyFile> DependencyFiles { get; set; }
 
         /// <summary>
         /// Download attempts

--- a/Cognite.Simulator.Utils/FileState.cs
+++ b/Cognite.Simulator.Utils/FileState.cs
@@ -111,6 +111,24 @@ namespace Cognite.Simulator.Utils
             }
         }
 
+        private List<DependencyFile> _dependencyFiles;
+
+        /// <summary>
+        /// List of dependency files that the main model file requires to function correctly.
+        /// Each dependency file has a unique identifier, a path on disk, and arguments providing additional metadata about how the file should be used in the model.
+        /// Only used by simulators that work with multi-file models.
+        /// </summary>
+        public List<DependencyFile> DependencyFiles
+        {
+            get => _dependencyFiles;
+            set
+            {
+                if (value == _dependencyFiles) return;
+                LastTimeModified = DateTime.UtcNow;
+                _dependencyFiles = value;
+            }
+        }
+
         private string _filePath;
 
         /// <summary>
@@ -292,6 +310,28 @@ namespace Cognite.Simulator.Utils
     }
 
     /// <summary>
+    /// Represents a dependency file that the main model file requires to function
+    /// </summary>
+    public class DependencyFile
+    {
+        /// <summary>
+        /// A unique identifier of a file in CDF.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Additional arguments or parameters associated with this dependency, used to provide metadata about how the file should be used by the simulator.
+        /// For example: {"simulatorObject": "well_1"}
+        /// </summary>
+        public Dictionary<string, string> Arguments { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// The absolute path where the dependency file is stored on disk
+        /// </summary>
+        public string FilePath { get; set; }
+    }
+
+    /// <summary>
     /// Data object that contains the state properties to be persisted
     /// by the state store. These properties are restored to the state on initialization
     /// </summary>
@@ -332,6 +372,14 @@ namespace Cognite.Simulator.Utils
         /// </summary>
         [StateStoreProperty("data-set-id")]
         public long? DataSetId { get; set; }
+
+        /// <summary>
+        /// List of dependency files that the main model file requires to function correctly.
+        /// Each dependency file has a unique identifier, a path on disk, and optional
+        /// arguments providing additional metadata about how the file should be used.
+        /// </summary>
+        [StateStoreProperty("dependency-files")]
+        public List<DependencyFile> DependencyFiles { get; set; } = new List<DependencyFile>();
 
         /// <summary>
         /// Path to the file in the local disk

--- a/Cognite.Simulator.Utils/FileState.cs
+++ b/Cognite.Simulator.Utils/FileState.cs
@@ -111,7 +111,6 @@ namespace Cognite.Simulator.Utils
             }
         }
 
-
         private string _filePath;
 
         /// <summary>
@@ -335,9 +334,7 @@ namespace Cognite.Simulator.Utils
         /// <summary>
         /// Initializes a new instance of the <see cref="DependencyFile"/> class.
         /// </summary>
-        public DependencyFile()
-        {
-        }
+        public DependencyFile() { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DependencyFile"/> class.

--- a/Cognite.Simulator.Utils/FileState.cs
+++ b/Cognite.Simulator.Utils/FileState.cs
@@ -5,6 +5,8 @@ using System.Text;
 using Cognite.Extractor.StateStorage;
 using Cognite.Simulator.Extensions;
 
+using CogniteSdk.Alpha;
+
 namespace Cognite.Simulator.Utils
 {
     /// <summary>
@@ -329,6 +331,19 @@ namespace Cognite.Simulator.Utils
         /// The absolute path where the dependency file is stored on disk
         /// </summary>
         public string FilePath { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DependencyFile"/> class.
+        /// </summary>
+        public DependencyFile(SimulatorFileDependency fileDependency)
+        {
+            if (fileDependency == null)
+            {
+                throw new ArgumentNullException(nameof(fileDependency));
+            }
+            Id = fileDependency.File.Id;
+            Arguments = fileDependency.Arguments;
+        }
     }
 
     /// <summary>

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -175,6 +175,8 @@ namespace Cognite.Simulator.Utils
                     true,
                     token).ConfigureAwait(false);
 
+                await FindModelRevisions(false, token).ConfigureAwait(false);
+
                 await _store.RestoreExtractionState<U, T>(
                     _state,
                     _config.FilesTable,
@@ -183,8 +185,6 @@ namespace Cognite.Simulator.Utils
                         state.Init(poco);
                     },
                     token).ConfigureAwait(false);
-
-                await FindModelRevisions(false, token).ConfigureAwait(false);
 
                 if (_store is LiteDBStateStore ldbStore)
                 {
@@ -253,7 +253,7 @@ namespace Cognite.Simulator.Utils
 
             if (!downloaded && modelState.DownloadAttempts < _config.MaxDownloadAttempts)
             {
-                downloaded = await DownloadAllFilesForModelAsync(modelState).ConfigureAwait(false);
+                downloaded = await DownloadAllModelFilesAsync(modelState).ConfigureAwait(false);
             }
 
             if (downloaded && modelState.ShouldProcess())
@@ -571,7 +571,7 @@ namespace Cognite.Simulator.Utils
         /// <param name="modelState">State object representing the model to download
         /// Such files are used once to run a simulation with a model that is not available in the state upon at a give time.</param>
         /// <returns>True if the file was downloaded successfully, false otherwise</returns>
-        private async Task<bool> DownloadAllFilesForModelAsync(T modelState)
+        private async Task<bool> DownloadAllModelFilesAsync(T modelState)
         {
             if (modelState == null)
             {
@@ -643,7 +643,7 @@ namespace Cognite.Simulator.Utils
         /// <summary>
         /// Downloads a file from CDF and stores it locally
         /// Such files are used once to run a simulation with a model that is not available in the state upon at a give time.
-        /// Each file serve as either a main model file or as a dependency to a model.
+        /// Each file serves as either a main model file or as a dependency to a model.
         /// </summary>
         /// <param name="fileId">ID of the file to download</param>
         /// <param name="fileExtension">File extension to use for the downloaded file</param>
@@ -654,7 +654,7 @@ namespace Cognite.Simulator.Utils
             try
             {
                 var downloadUriRes = await _cdfFiles
-                    .DownloadAsync([new Identity(fileId)])
+                    .DownloadAsync(new[] { fileId })
                     .ConfigureAwait(false);
 
                 var downloadUri = downloadUriRes.FirstOrDefault()?.DownloadUrl;

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -577,11 +577,13 @@ namespace Cognite.Simulator.Utils
 
             modelState.DownloadAttempts++;
 
-            _logger.LogInformation("Downloading files for model revision external ID: {ExternalId}. Attempt: {DownloadAttempts}",
-               modelState.ExternalId,
-               modelState.DownloadAttempts);
 
             var fileIds = modelState.GetPendingDownloadFileIds(); // TODO: this whould only list non-existing ones
+
+            _logger.LogInformation("Downloading {Count} file(s) for model revision external ID: {ExternalId}. Attempt: {DownloadAttempts}",
+                fileIds.Count,
+                modelState.ExternalId,
+                modelState.DownloadAttempts);
 
             var files = await _cdfFiles
                 .RetrieveAsync(fileIds, ignoreUnknownIds: true)
@@ -598,8 +600,8 @@ namespace Cognite.Simulator.Utils
                 var isMainFile = fileId == modelState.CdfId;
                 if (filesMap.TryGetValue(fileId, out var file))
                 {
-                    _logger.LogInformation("Downloading file ({FileIndex}/{FilesTotal}): {Id}. Model revision external ID: {ExternalId}.",
-                        fileIndex,
+                    _logger.LogInformation("Downloading file ({FileNumber}/{FilesTotal}): {Id}. Model revision external ID: {ExternalId}.",
+                        fileIndex + 1,
                         fileIds.Count,
                         fileId,
                         modelState.ExternalId);

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -567,6 +567,7 @@ namespace Cognite.Simulator.Utils
 
         /// <summary>
         /// Downloads all files associated with a model state and stores them locally.
+        /// Updates the model state with the file paths of the downloaded files.
         /// </summary>
         /// <param name="modelState">State object representing the model to download
         /// Such files are used once to run a simulation with a model that is not available in the state upon at a give time.</param>

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -621,11 +621,7 @@ namespace Cognite.Simulator.Utils
                         }
                         else
                         {
-                            modelState.UpdateDependencyFile(fileId, (dependency) =>
-                            {
-                                dependency.FilePath = filePath;
-                                return dependency;
-                            });
+                            modelState.UpdateDependencyFilePath(fileId, filePath);
                         }
                     }
                 }

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -185,7 +185,6 @@ namespace Cognite.Simulator.Utils
                         state.Init(poco);
                     },
                     token).ConfigureAwait(false);
-
                 if (_store is LiteDBStateStore ldbStore)
                 {
                     HashSet<string> idsToKeep = new HashSet<string>(_state.Select(s => s.Value.Id));
@@ -578,9 +577,7 @@ namespace Cognite.Simulator.Utils
             {
                 throw new ArgumentNullException(nameof(modelState));
             }
-
             modelState.DownloadAttempts++;
-
 
             var fileIds = modelState.GetPendingDownloadFileIds();
 

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -581,7 +581,7 @@ namespace Cognite.Simulator.Utils
             modelState.DownloadAttempts++;
 
 
-            var fileIds = modelState.GetPendingDownloadFileIds(); // TODO: this should only list non-existing ones
+            var fileIds = modelState.GetPendingDownloadFileIds();
 
             _logger.LogInformation("Downloading {Count} file(s) for model revision external ID: {ExternalId}. Attempt: {DownloadAttempts}",
                 fileIds.Count,
@@ -590,7 +590,7 @@ namespace Cognite.Simulator.Utils
 
             var files = await _cdfFiles
                 .RetrieveAsync(fileIds, ignoreUnknownIds: true)
-                .ConfigureAwait(false); // todo: make batch version
+                .ConfigureAwait(false); // TODO: make batch version to support more than 1k https://cognitedata.atlassian.net/browse/POFSP-1139
 
             var filesMap = files.ToDictionarySafe(file => file.Id, file => file);
 

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -175,8 +175,6 @@ namespace Cognite.Simulator.Utils
                     true,
                     token).ConfigureAwait(false);
 
-                await FindModelRevisions(false, token).ConfigureAwait(false);
-
                 await _store.RestoreExtractionState<U, T>(
                     _state,
                     _config.FilesTable,
@@ -185,6 +183,9 @@ namespace Cognite.Simulator.Utils
                         state.Init(poco);
                     },
                     token).ConfigureAwait(false);
+
+                await FindModelRevisions(false, token).ConfigureAwait(false);
+
                 if (_store is LiteDBStateStore ldbStore)
                 {
                     HashSet<string> idsToKeep = new HashSet<string>(_state.Select(s => s.Value.Id));
@@ -536,6 +537,8 @@ namespace Cognite.Simulator.Utils
                 {
                     await VerifyLocalModelState(group.First(), token).ConfigureAwait(false);
                 }
+
+                await SaveStates(token).ConfigureAwait(false);
             }
             catch (ResponseException e)
             {
@@ -578,7 +581,7 @@ namespace Cognite.Simulator.Utils
             modelState.DownloadAttempts++;
 
 
-            var fileIds = modelState.GetPendingDownloadFileIds(); // TODO: this whould only list non-existing ones
+            var fileIds = modelState.GetPendingDownloadFileIds(); // TODO: this should only list non-existing ones
 
             _logger.LogInformation("Downloading {Count} file(s) for model revision external ID: {ExternalId}. Attempt: {DownloadAttempts}",
                 fileIds.Count,
@@ -723,8 +726,6 @@ namespace Cognite.Simulator.Utils
                 // Find new model files in CDF and add the to the local state.
                 await FindModelRevisions(true, token)
                     .ConfigureAwait(false);
-
-                await SaveStates(token).ConfigureAwait(false);
 
                 await Task
                     .Delay(TimeSpan.FromSeconds(_config.LibraryUpdateInterval), token)

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -252,7 +252,7 @@ namespace Cognite.Simulator.Utils
 
             if (!downloaded && modelState.DownloadAttempts < _config.MaxDownloadAttempts)
             {
-                downloaded = await DownloadFileAsync(modelState).ConfigureAwait(false);
+                downloaded = await DownloadAllFilesForModelAsync(modelState).ConfigureAwait(false);
             }
 
             if (downloaded && modelState.ShouldProcess())
@@ -563,83 +563,144 @@ namespace Cognite.Simulator.Utils
         }
 
         /// <summary>
-        /// Downloads a file from CDF and stores it locally
+        /// Downloads all files associated with a model state and stores them locally.
         /// </summary>
-        /// <param name="modelState">State object representing the file to download
+        /// <param name="modelState">State object representing the model to download
         /// Such files are used once to run a simulation with a model that is not available in the state upon at a give time.</param>
         /// <returns>True if the file was downloaded successfully, false otherwise</returns>
-        private async Task<bool> DownloadFileAsync(T modelState)
+        private async Task<bool> DownloadAllFilesForModelAsync(T modelState)
         {
             if (modelState == null)
             {
                 throw new ArgumentNullException(nameof(modelState));
             }
-            var fileId = new Identity(modelState.CdfId);
-            modelState.DownloadAttempts++;
-            _logger.LogInformation("Downloading file: {Id}. Model revision external id: {ExternalId}. Attempt: {DownloadAttempts}",
-                modelState.CdfId,
-                modelState.ExternalId,
-                modelState.DownloadAttempts);
 
+            modelState.DownloadAttempts++;
+
+            _logger.LogInformation("Downloading files for model revision external ID: {ExternalId}. Attempt: {DownloadAttempts}",
+               modelState.ExternalId,
+               modelState.DownloadAttempts);
+
+            var fileIds = modelState.GetPendingDownloadFileIds(); // TODO: this whould only list non-existing ones
+
+            var files = await _cdfFiles
+                .RetrieveAsync(fileIds, ignoreUnknownIds: true)
+                .ConfigureAwait(false); // todo: make batch version
+
+            var filesMap = files.ToDictionarySafe(file => file.Id, file => file);
+
+            bool allFilesDownloaded = true;
+
+            for (int fileIndex = 0; fileIndex < fileIds.Count; fileIndex++)
+            {
+                var downloaded = false;
+                var fileId = fileIds[fileIndex];
+                var isMainFile = fileId == modelState.CdfId;
+                if (filesMap.TryGetValue(fileId, out var file))
+                {
+                    _logger.LogInformation("Downloading file ({FileIndex}/{FilesTotal}): {Id}. Model revision external ID: {ExternalId}.",
+                        fileIndex,
+                        fileIds.Count,
+                        fileId,
+                        modelState.ExternalId);
+                    var fileExtension = file.GetExtension();
+                    string filePath = await DownloadFileAsync(fileId, fileExtension, modelState.ExternalId).ConfigureAwait(false);
+                    downloaded = !string.IsNullOrEmpty(filePath);
+                    if (downloaded)
+                    {
+                        if (isMainFile)
+                        {
+                            modelState.IsInDirectory = true;
+                            modelState.FilePath = filePath;
+                            modelState.FileExtension = fileExtension;
+                        }
+                        else
+                        {
+                            modelState.UpdateDependencyFile(fileId, (dependency) =>
+                            {
+                                dependency.FilePath = filePath;
+                                return dependency;
+                            });
+                        }
+                    }
+                }
+                else
+                {
+                    _logger.LogWarning("File with ID {FileId} not found in CDF for model revision {ExternalId}",
+                        fileId, modelState.ExternalId);
+                }
+                allFilesDownloaded &= downloaded;
+            }
+
+            return allFilesDownloaded;
+        }
+
+        /// <summary>
+        /// Downloads a file from CDF and stores it locally
+        /// Such files are used once to run a simulation with a model that is not available in the state upon at a give time.
+        /// Each file serve as either a main model file or as a dependency to a model.
+        /// </summary>
+        /// <param name="fileId">ID of the file to download</param>
+        /// <param name="fileExtension">File extension to use for the downloaded file</param>
+        /// <param name="modelRevisionExternalId">External ID of the model revision to which the file belongs.</param>
+        /// <returns>File path where the file was downloaded, or null if the download failed</returns>
+        private async Task<string> DownloadFileAsync(long fileId, string fileExtension, string modelRevisionExternalId)
+        {
             try
             {
-                var fileRes = await _cdfFiles
-                    .RetrieveAsync([fileId])
-                    .ConfigureAwait(false);
-                var file = fileRes.FirstOrDefault();
-
                 var downloadUriRes = await _cdfFiles
-                    .DownloadAsync(new[] { fileId })
+                    .DownloadAsync([new Identity(fileId)])
                     .ConfigureAwait(false);
 
                 var downloadUri = downloadUriRes.FirstOrDefault()?.DownloadUrl;
 
-                if (file != null && downloadUri != null)
+                if (downloadUri != null)
                 {
-                    var fileExtension = file.GetExtension();
-                    var storageFolder = Path.Combine(_modelFolder, $"{file.Id}");
-                    var filename = Path.Combine(storageFolder, $"{file.Id}.{fileExtension}");
+                    var storageFolder = Path.Combine(_modelFolder, $"{fileId}");
                     CreateDirectoryIfNotExists(storageFolder);
-                    modelState.IsInDirectory = true;
 
+                    var filePath = Path.Combine(storageFolder, $"{fileId}.{fileExtension}");
                     bool downloaded = await _downloadClient
-                        .DownloadFileAsync(downloadUri, filename)
+                        .DownloadFileAsync(downloadUri, filePath)
                         .ConfigureAwait(false);
+
                     if (downloaded)
                     {
                         _logger.LogDebug("File downloaded: {Id}. Model revision: {ExternalId}. File path: {FilePath}",
-                            modelState.CdfId,
-                            modelState.ExternalId,
-                            filename);
-                        modelState.FilePath = filename;
-                        modelState.FileExtension = fileExtension;
-                        return true;
+                            fileId,
+                            modelRevisionExternalId,
+                            filePath);
+
+                        return filePath;
                     }
                 }
             }
             catch (ResponseException e)
             {
                 // File cannot be downloaded, skip for now and try again later
-                _logger.LogWarning("Failed to fetch file url from CDF: {Message}. Model revision: {ExternalId}",
+                _logger.LogWarning("Failed to fetch file url from CDF: {Message}. Model revision: {ExternalId}. File ID: {FileId}",
                     e.Message,
-                    modelState.ExternalId
+                    modelRevisionExternalId,
+                    fileId
                 );
             }
             catch (ConnectorException e)
             {
-                _logger.LogWarning("Failed to download file: {Message}. Model revision: {ExternalId}",
+                _logger.LogWarning("Failed to download file: {Message}. Model revision: {ExternalId}. File ID: {FileId}",
                     e.Message,
-                    modelState.ExternalId
+                    modelRevisionExternalId,
+                    fileId
                 );
             }
             catch (Exception e)
             {
-                _logger.LogError("Error occurred while downloading the file for model revision {ExternalId}: {Error}",
-                    modelState.ExternalId,
+                _logger.LogError("Error occurred while downloading the file for model revision {ExternalId}. File ID {FileId}: {Error}",
+                    modelRevisionExternalId,
+                    fileId,
                     e
                 );
             }
-            return false;
+            return null;
         }
 
         /// <summary>

--- a/Cognite.Simulator.Utils/ModelStateBase.cs
+++ b/Cognite.Simulator.Utils/ModelStateBase.cs
@@ -50,13 +50,14 @@ namespace Cognite.Simulator.Utils
 
         /// <summary>
         /// Indicates if the model file has been downloaded and the file exists on the disk.
+        /// Also checks if all dependency files have their paths assigned (without checking the file existence).
         /// </summary>
         public bool Downloaded
         {
             get
             {
-                // TODO: extend this to verify the dependency files as well https://cognitedata.atlassian.net/browse/POFSP-1137
-                return !string.IsNullOrEmpty(FilePath) && System.IO.File.Exists(FilePath);
+                var dependenciesDownloaded = DependencyFiles.All(file => !string.IsNullOrEmpty(file.FilePath)); // too expensive to check file existence here
+                return !string.IsNullOrEmpty(FilePath) && System.IO.File.Exists(FilePath) && dependenciesDownloaded;
             }
         }
 

--- a/Cognite.Simulator.Utils/ModelStateBase.cs
+++ b/Cognite.Simulator.Utils/ModelStateBase.cs
@@ -74,10 +74,9 @@ namespace Cognite.Simulator.Utils
                 throw new ArgumentException(nameof(CdfId), "Model state must have a valid CDF ID.");
             }
 
-            // TOD0: this should only return the IDs of the files that are not downloaded yet https://cognitedata.atlassian.net/browse/POFSP-1137
             var fileIds = new List<long> { CdfId };
 
-            fileIds.AddRange(DependencyFiles.Select(file => file.Id));
+            fileIds.AddRange(DependencyFiles.Select(file => file.Id)); // TODO: this should only return the IDs of the files that are not downloaded yet https://cognitedata.atlassian.net/browse/POFSP-1137
 
             return fileIds;
         }

--- a/Cognite.Simulator.Utils/ModelStateBase.cs
+++ b/Cognite.Simulator.Utils/ModelStateBase.cs
@@ -55,6 +55,7 @@ namespace Cognite.Simulator.Utils
         {
             get
             {
+                // TODO: extend this to verify the dependency files as well https://cognitedata.atlassian.net/browse/POFSP-1137
                 return !string.IsNullOrEmpty(FilePath) && System.IO.File.Exists(FilePath);
             }
         }
@@ -72,6 +73,7 @@ namespace Cognite.Simulator.Utils
                 throw new ArgumentNullException(nameof(CdfId), "Model state must have a valid CDF ID.");
             }
 
+            // TOD0: this should only return the IDs of the files that are not downloaded yet https://cognitedata.atlassian.net/browse/POFSP-1137
             var fileIds = new List<long> { CdfId };
 
             if (DependencyFiles != null)
@@ -83,11 +85,11 @@ namespace Cognite.Simulator.Utils
         }
 
         /// <summary>
-        /// 
+        /// Updates a dependency by calling the provided update function.
+        /// Throws an exception if the file does not exist in the state.
         /// </summary>
         /// <param name="fileId">The ID of the dependency file</param>
         /// <param name="updateFunc">Function that takes a DependencyFile and returns an updated DependencyFile</param>
-        /// <returns>True if the operation was successful</returns>
         /// <exception cref="ArgumentNullException">Thrown if dependencyFile is null</exception>
         public void UpdateDependencyFile(long fileId, Func<DependencyFile, DependencyFile> updateFunc)
         {

--- a/Cognite.Simulator.Utils/ModelStateBase.cs
+++ b/Cognite.Simulator.Utils/ModelStateBase.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using Cognite.Extensions;
-using Cognite.Extractor.StateStorage;
 using Cognite.Simulator.Extensions;
 
 
@@ -78,10 +76,7 @@ namespace Cognite.Simulator.Utils
 
             if (DependencyFiles != null)
             {
-                var dependencyFiles = DependencyFiles
-                    .ToDictionarySafe(file => file.Id, file => file);
-
-                fileIds.AddRange(dependencyFiles.Keys);
+                fileIds.AddRange(DependencyFiles.Select(file => file.Id));
             }
 
             return fileIds;

--- a/Cognite.Simulator.Utils/ModelStateBase.cs
+++ b/Cognite.Simulator.Utils/ModelStateBase.cs
@@ -94,7 +94,7 @@ namespace Cognite.Simulator.Utils
         /// <param name="updateFunc">Function that takes a DependencyFile and returns an updated DependencyFile</param>
         /// <returns>True if the operation was successful</returns>
         /// <exception cref="ArgumentNullException">Thrown if dependencyFile is null</exception>
-        public bool UpdateDependencyFile(long fileId, Func<DependencyFile, DependencyFile> updateFunc)
+        public void UpdateDependencyFile(long fileId, Func<DependencyFile, DependencyFile> updateFunc)
         {
             if (updateFunc == null)
             {
@@ -108,11 +108,11 @@ namespace Cognite.Simulator.Utils
                 if (indexOf >= 0)
                 {
                     DependencyFiles[indexOf] = updateFunc(DependencyFiles[indexOf]);
-                    return true;
+                    return;
                 }
             }
 
-            return false;
+            throw new InvalidOperationException($"Dependency file with ID {fileId} not found in the model state.");
         }
 
 

--- a/Cognite.Simulator.Utils/ModelStateBase.cs
+++ b/Cognite.Simulator.Utils/ModelStateBase.cs
@@ -65,48 +65,42 @@ namespace Cognite.Simulator.Utils
         /// This includes the main file ID and any dependency files.
         /// </summary>
         /// <returns>List of file IDs pending download</returns>
-        /// <exception cref="ArgumentNullException">Thrown if CdfId is not set</exception>
+        /// <exception cref="ArgumentException">Thrown if CdfId is not set</exception>
         public List<long> GetPendingDownloadFileIds()
         {
             if (CdfId == 0)
             {
-                throw new ArgumentNullException(nameof(CdfId), "Model state must have a valid CDF ID.");
+                throw new ArgumentException(nameof(CdfId), "Model state must have a valid CDF ID.");
             }
 
             // TOD0: this should only return the IDs of the files that are not downloaded yet https://cognitedata.atlassian.net/browse/POFSP-1137
             var fileIds = new List<long> { CdfId };
 
-            if (DependencyFiles != null)
-            {
-                fileIds.AddRange(DependencyFiles.Select(file => file.Id));
-            }
+            fileIds.AddRange(DependencyFiles.Select(file => file.Id));
 
             return fileIds;
         }
 
         /// <summary>
-        /// Updates a dependency by calling the provided update function.
-        /// Throws an exception if the file does not exist in the state.
+        /// Updates the file path of a dependency file.
+        /// Throws an exception if the file reference does not exist in the state.
         /// </summary>
         /// <param name="fileId">The ID of the dependency file</param>
-        /// <param name="updateFunc">Function that takes a DependencyFile and returns an updated DependencyFile</param>
+        /// <param name="filePath">The new file path for the dependency file</param>
         /// <exception cref="ArgumentNullException">Thrown if dependencyFile is null</exception>
-        public void UpdateDependencyFile(long fileId, Func<DependencyFile, DependencyFile> updateFunc)
+        public void UpdateDependencyFilePath(long fileId, string filePath)
         {
-            if (updateFunc == null)
+            if (string.IsNullOrEmpty(filePath))
             {
-                throw new ArgumentNullException(nameof(updateFunc), "Update function cannot be null.");
+                throw new ArgumentNullException(nameof(filePath), "File path cannot be null or empty.");
             }
 
-            if (DependencyFiles != null)
-            {
-                var indexOf = DependencyFiles.FindIndex(file => file.Id == fileId);
+            var indexOf = DependencyFiles.FindIndex(file => file.Id == fileId);
 
-                if (indexOf >= 0)
-                {
-                    DependencyFiles[indexOf] = updateFunc(DependencyFiles[indexOf]);
-                    return;
-                }
+            if (indexOf >= 0)
+            {
+                DependencyFiles[indexOf].FilePath = filePath;
+                return;
             }
 
             throw new InvalidOperationException($"Dependency file with ID {fileId} not found in the model state.");


### PR DESCRIPTION
This is an unfinished feature and still needs polishing and robustness, but the PR is already bit enough, so the improvements will come stacked.

There are a few TODOs in the code - those are tickets for this/next sprint. 

**WHY**
We are building a feature would allow support of large model file (dozen of GBs) for specific simulator connectors with a portial update capability. The way this is done is that one model revision can reference multiple smaller files as dependencies. So when one of the dependencies changed, the connector would not need to download the whole large model, but just a small part of it.
https://cognitedata.atlassian.net/wiki/spaces/PD/pages/5216337994/Thoughts+on+how+to+support+external+dependencies


**What changed**
This PR instroduces support for the changes in the API https://api-docs.cognite.com/internal/tag/Simulator-Models/operation/create_simulator_model_revision_simulators_models_revisions_post
One the model revision is read from the API, each file in the list is then downloaded for each model and the Path is saved to the local state `DependencyFiles` property (in memory + LiteDB).

There will be more things needed here (e.g. deduplication, if a model revision needs a file that is already downloaded, batching, etc).

We don't release the library just yet, so this feature is not going to be used by anyone yet.
<img width="789" height="479" alt="Screenshot 2025-08-06 at 14 22 06" src="https://github.com/user-attachments/assets/d920e89f-0f6d-4cdf-bad0-50ddf1a29ab7" />
