### PR TITLE
test: improved parallelism & more convenient test utilities

### DIFF
--- a/Cognite.Simulator.Tests/CdfTestClient.cs
+++ b/Cognite.Simulator.Tests/CdfTestClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Cognite.Extensions;
@@ -27,7 +28,7 @@ namespace Cognite.Simulator.Tests
         private static int _configIdx;
         private static string? _statePath;
 
-        public static IServiceCollection AddCogniteTestClient(this IServiceCollection services)
+        public static IServiceCollection AddCogniteTestClient(this IServiceCollection services, [CallerMemberName] string? testCallerName = null)
         {
             var host = Environment.GetEnvironmentVariable("COGNITE_HOST");
             var project = Environment.GetEnvironmentVariable("COGNITE_PROJECT");
@@ -40,7 +41,7 @@ namespace Cognite.Simulator.Tests
             }
 
             var index = Interlocked.Increment(ref _configIdx);
-            _statePath = $"test-state-{index}";
+            _statePath = testCallerName != null ? $"test-state-{testCallerName}" : $"test-state-{index}";
 
             var authConfig = new AuthenticatorConfig
             {

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
@@ -50,8 +50,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             using var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(3));
 
-            var mocks = GetMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
-            var mockFactory = mocks.factory;
+            var mockFactory = GetMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
 
             DefaultConnectorRuntime<DefaultAutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>.ConfigureServices = (services) =>
             {

--- a/Cognite.Simulator.Tests/UtilsTests/ExtPipelineUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ExtPipelineUnitTest.cs
@@ -51,8 +51,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var services = new ServiceCollection();
             services.AddSingleton(SeedData.SimulatorCreate);
 
-            var httpMock = GetMockedHttpClientFactory(MockRequestsAsync(endpointMappings));
-            var mockFactory = httpMock.factory;
+            var mockFactory = GetMockedHttpClientFactory(MockRequestsAsync(endpointMappings));
             services.AddSingleton(mockFactory.Object);
             services.AddCogniteTestClient();
 
@@ -100,8 +99,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             var services = new ServiceCollection();
             services.AddSingleton(SeedData.SimulatorCreate);
 
-            var httpMock = GetMockedHttpClientFactory(MockRequestsAsync(endpointMappingsDisabled));
-            var mockFactory = httpMock.factory;
+            var mockFactory = GetMockedHttpClientFactory(MockRequestsAsync(endpointMappingsDisabled));
             services.AddSingleton(mockFactory.Object);
             services.AddCogniteTestClient();
 

--- a/Cognite.Simulator.Tests/UtilsTests/FileStorageClientUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/FileStorageClientUnitTest.cs
@@ -34,8 +34,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             };
 
             var services = new ServiceCollection();
-            var httpMocks = GetMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
-            var mockHttpClientFactory = httpMocks.factory;
+            var mockHttpClientFactory = GetMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
             var mockedLogger = new Mock<ILogger<FileStorageClient>>();
 
             services.AddSingleton(mockHttpClientFactory.Object);

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -25,8 +25,16 @@ namespace Cognite.Simulator.Tests.UtilsTests
     /// Tests for the ModelLibraryBase class that focus on the concurrency aspects.
     /// Uses FakeModelLibrary and SimpleRequestMocker to mock the HTTP layer.
     /// </summary>
-    public class ModelLibraryConcurrencyTest
+    public class ModelLibraryConcurrencyTest : IDisposable
     {
+        StateStoreConfig? stateConfig;
+        ModelLibraryConfig? modelLibraryConfig;
+
+        public void Dispose()
+        {
+            CleanUpFiles(modelLibraryConfig, stateConfig);
+        }
+
         private static readonly IList<SimpleRequestMocker> endpointMockTemplates = new List<SimpleRequestMocker>
         {
             new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
@@ -60,7 +68,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
             using var provider = services.BuildServiceProvider();
 
-            var stateConfig = provider.GetRequiredService<StateStoreConfig>();
+            stateConfig = provider.GetRequiredService<StateStoreConfig>();
+            modelLibraryConfig = provider.GetRequiredService<DefaultConfig<AutomationConfig>>().Connector.ModelLibrary;
             using var source = new CancellationTokenSource();
             var lib = provider.GetRequiredService<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
             await lib.Init(source.Token);

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -46,21 +46,17 @@ namespace Cognite.Simulator.Tests.UtilsTests
         [Fact]
         public async Task TestModelLibraryConcurrentCalls()
         {
-            var httpMocks = GetMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
             var mockedLogger = new Mock<ILogger<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>>();
 
             var services = new ServiceCollection();
-            services.AddSingleton(httpMocks.factory.Object);
+            services.AddMockedHttpClientFactory(MockRequestsAsync(endpointMockTemplates));
             services.AddCogniteTestClient();
             services.AddSingleton(mockedLogger.Object);
             services.AddSingleton<ISimulatorClient<DefaultModelFilestate, SimulatorRoutineRevision>, FakeSimulatorClient>();
             services.AddSingleton<FileStorageClient>();
             services.AddSingleton<DefaultModelLibrary<AutomationConfig, DefaultModelFilestate, DefaultModelFileStatePoco>>();
             services.AddSingleton(SeedData.SimulatorCreate);
-
-            var config = new DefaultConfig<AutomationConfig>();
-            config.GenerateDefaults();
-            services.AddSingleton(config);
+            services.AddDefaultConfig();
 
             using var provider = services.BuildServiceProvider();
 

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryConcurrencyUnitTest.cs
@@ -44,7 +44,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
             new SimpleRequestMocker(uri => uri.Contains("/files/downloadlink"), MockFilesDownloadLinkEndpoint, 1),
             new SimpleRequestMocker(uri => uri.Contains("/files/download"), () => MockFilesDownloadEndpoint(1), 1),
-            new SimpleRequestMocker(uri => true, () => GoneResponse)
+            new SimpleRequestMocker(uri => true, () => GoneResponse).ShouldBeCalled(Times.AtMost(100)) // doesn't matter
         };
 
         /// <summary>

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
@@ -19,30 +19,13 @@ using Microsoft.Extensions.Logging;
 
 using Xunit;
 
+using static Cognite.Simulator.Tests.UtilsTests.TestUtilities;
+
 namespace Cognite.Simulator.Tests.UtilsTests
 {
     [Collection(nameof(SequentialTestCollection))]
     public class ModelLibraryTest
     {
-        private static void CleanUp(bool deleteDirectory, StateStoreConfig? stateConfig)
-        {
-            try
-            {
-                if (deleteDirectory && Directory.Exists("./files"))
-                {
-                    Directory.Delete("./files", true);
-                }
-                if (stateConfig != null)
-                {
-                    StateUtils.DeleteLocalFile(stateConfig.Location);
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error cleaning up: {ex.Message}");
-            }
-        }
-
         [Fact]
         public async Task TestModelLibrary()
         {
@@ -153,7 +136,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
             finally
             {
-                CleanUp(true, stateConfig);
+                CleanUpFiles(null, stateConfig);
                 await SeedData.DeleteSimulator(cdf, SeedData.SimulatorCreate.ExternalId);
             }
         }
@@ -280,7 +263,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
             finally
             {
-                CleanUp(true, stateConfig);
+                CleanUpFiles(null, stateConfig);
                 await SeedData.DeleteSimulator(cdf, SeedData.SimulatorCreate.ExternalId);
             }
         }
@@ -353,7 +336,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
             finally
             {
-                CleanUp(true, stateConfig);
+                CleanUpFiles(null, stateConfig);
                 await SeedData.DeleteSimulator(cdf, SeedData.SimulatorCreate.ExternalId);
             }
         }
@@ -430,7 +413,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
             finally
             {
-                CleanUp(false, stateConfig);
+                CleanUpFiles(null, stateConfig);
                 await SeedData.DeleteSimulator(cdf.CogniteClient, SeedData.SimulatorCreate.ExternalId);
             }
         }
@@ -497,7 +480,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             }
             finally
             {
-                CleanUp(false, stateConfig);
+                CleanUpFiles(null, stateConfig);
                 await SeedData.DeleteSimulator(cdf.CogniteClient, SeedData.SimulatorCreate.ExternalId);
 
             }

--- a/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
@@ -24,6 +24,10 @@ namespace Cognite.Simulator.Tests.UtilsTests
 {
     public static class TestUtilities
     {
+        /// <summary>
+        /// Creates a mocked IHttpClientFactory that provides a new HttpClient instance with a fresh mock handler for each invocation.
+        /// This approach ensures isolation between tests by preventing shared state in HTTP handlers.
+        /// </summary>
         public static Mock<IHttpClientFactory> GetMockedHttpClientFactory(
             Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> mockSendAsync)
         {

--- a/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/TestUtilities.cs
@@ -52,11 +52,12 @@ namespace Cognite.Simulator.Tests.UtilsTests
             return (mockFactory, mockHttpMessageHandler);
         }
 
-        public static void AddDefaultConfig(this ServiceCollection services, [CallerMemberName] string? testCallerName = "Default")
+        public static void AddDefaultConfig(this ServiceCollection services, [CallerMemberName] string? testCallerName = null)
         {
             var config = new DefaultConfig<AutomationConfig>();
             config.GenerateDefaults();
-            config.Connector.ModelLibrary.FilesDirectory = $"./files-{testCallerName}";
+            var filesDirectory = testCallerName != null ? $"./files-{testCallerName}" : $"./files";
+            config.Connector.ModelLibrary.FilesDirectory = filesDirectory;
             services.AddSingleton(config);
         }
 


### PR DESCRIPTION
The is a prerequisite for another change.
1. We currently cannot concurrently run tests that use LiteDb / disk, since they step on each other toes.
It's somewhat okay for e2e integration tests, but there is no reason we shoud not be able to run unit tests (with mocked http client) in parallel.
This fixes that by adding a postfix to the file / folder being used by the test. 
2. Added convenience utilities AddMockedHttpClientFactory and AddDefaultConfig to simplify test boilerplate

Also added cleanup step for [ModelLibraryConcurrencyTest](https://github.com/cognitedata/dotnet-simulator-utils/pull/283/commits/c62f63ce079cea084d3b1efb153f5b31ed60d18c) (from prev PR)