### PR TITLE
feat(modellib): restore extraction state on startup

### DIFF
--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
@@ -217,6 +217,11 @@ namespace Cognite.Simulator.Tests.UtilsTests
             VerifyLog(mockedLogger, LogLevel.Information, "Extracting model information for TestModelExternalId v1", Times.Exactly(1), true);
             VerifyLog(mockedLogger, LogLevel.Debug, "Restored 1 extraction state(s) from litedb store ModelLibraryFiles", Times.Exactly(1), true);
             VerifyLog(mockedLogger, LogLevel.Warning, "Failed to fetch model revisions from CDF", Times.Exactly(0), true);
+
+            foreach (var mocker in endpointMockTemplates)
+            {
+                mocker.AssertCallCount();
+            }
         }
 
         /// <summary>

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
@@ -216,6 +216,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             VerifyLog(mockedLogger, LogLevel.Error, "Error reading model revision from CDF", Times.Exactly(0), true);
             VerifyLog(mockedLogger, LogLevel.Information, "Extracting model information for TestModelExternalId v1", Times.Exactly(1), true);
             VerifyLog(mockedLogger, LogLevel.Debug, "Restored 1 extraction state(s) from litedb store ModelLibraryFiles", Times.Exactly(1), true);
+            VerifyLog(mockedLogger, LogLevel.Warning, "Failed to fetch model revisions from CDF", Times.Exactly(0), true);
         }
 
         /// <summary>

--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryExternalDepsTest.cs
@@ -137,9 +137,9 @@ namespace Cognite.Simulator.Tests.UtilsTests
             {
                 new SimpleRequestMocker(uri => uri.EndsWith("/token"), MockAzureAADTokenEndpoint),
                 new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/list"), MockSimulatorModelRevEndpoint(), 2),
-                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint(), 1),
-                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/update"), MockSimulatorModelRevEndpoint(), 1),
-                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint(1000, "v1", "success"), 2),
+                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint(), 1), // return "unknown" status on first call, this triggers model processing
+                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/update"), MockSimulatorModelRevEndpoint(), 1), // should happen only once since the state is restored from LiteDB on the second call to /revisions/byids
+                new SimpleRequestMocker(uri => uri.Contains("/simulators/models/revisions/byids"), MockSimulatorModelRevEndpoint(1000, "v1", "success"), 2), // return "success" status on second call, so we skip the processing, only used for restoring state
                 new SimpleRequestMocker(uri => uri.Contains("/files/byids"), MockFilesByIdsEndpoint, 1),
                 new SimpleRequestMocker(uri => uri.Contains("/files/downloadlink"), MockFilesDownloadLinkEndpoint, 3),
                 new SimpleRequestMocker(uri => uri.Contains("/files/download"), () => MockFilesDownloadEndpoint(1), 3),

--- a/Cognite.Simulator.Utils/DefaultClasses/DefaultModelState.cs
+++ b/Cognite.Simulator.Utils/DefaultClasses/DefaultModelState.cs
@@ -15,14 +15,7 @@ namespace Cognite.Simulator.Utils
     /// <summary>
     /// Default implementation of a model state
     /// </summary>
-    public class DefaultModelFileStatePoco : ModelStateBasePoco
-    {
-        /// <summary>
-        /// Gets a value indicating whether the information has been extracted.
-        /// </summary>
-        [StateStoreProperty("info-extracted")]
-        public bool InformationExtracted { get; internal set; }
-    }
+    public class DefaultModelFileStatePoco : ModelStateBasePoco { }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultModelFilestate"/> class.

--- a/Cognite.Simulator.Utils/FileState.cs
+++ b/Cognite.Simulator.Utils/FileState.cs
@@ -268,6 +268,7 @@ namespace Cognite.Simulator.Utils
             {
                 throw new ArgumentNullException(nameof(poco));
             }
+            Id = poco.Id;
             _source = poco.Source;
             _dataSetId = poco.DataSetId;
             _filePath = poco.FilePath;
@@ -276,6 +277,7 @@ namespace Cognite.Simulator.Utils
             _updatedTime = poco.UpdatedTime;
             _isInDirectory = poco.IsInDirectory;
             _externalId = poco.ExternalId;
+            _modelExternalId = poco.ModelExternalId;
             _logId = poco.LogId;
             _fileExtension = poco.FileExtension;
             _dependencyFiles = poco.DependencyFiles;
@@ -300,6 +302,7 @@ namespace Cognite.Simulator.Utils
                 CdfId = CdfId,
                 UpdatedTime = UpdatedTime,
                 IsInDirectory = IsInDirectory,
+                ModelExternalId = ModelExternalId,
                 ExternalId = ExternalId,
                 LogId = LogId,
                 FileExtension = FileExtension,

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -38,7 +38,7 @@ namespace Cognite.Simulator.Utils
     /// <typeparam name="V">Type of the model parsing information object</typeparam>
     public abstract class ModelLibraryBase<A, T, U, V> : IModelProvider<A, T>, IDisposable
         where A : AutomationConfig
-        where T : ModelStateBase
+        where T : ModelStateBase, new()
         where U : ModelStateBasePoco
         where V : ModelParsingInfo, new()
     {
@@ -159,6 +159,30 @@ namespace Cognite.Simulator.Utils
         }
 
         /// <summary>
+        /// The default IExtractionStateStore.RestoreExtractionState() only restores the items that exist in the state.
+        /// In our case we want to restore the items on startup before even calling the remote API.
+        /// This method reads all extraction states from the state store and adds them to the local state to resolve the issue.
+        /// </summary>
+        /// <param name="token">Cancellation token</param>
+        private async Task RestoreExtractionState(CancellationToken token)
+        {
+            var statesPocos = await _store.GetAllExtractionStates<U>(
+                _config.FilesTable,
+                token).ConfigureAwait(false);
+
+            foreach (var poco in statesPocos)
+            {
+                var state = new T();
+                state.Init(poco);
+                _state.TryAdd(state.Id, state);
+            }
+
+            _logger.LogDebug("Restored {Restored} extraction state(s) from litedb store {store}",
+                statesPocos.Count(),
+                _config.FilesTable);
+        }
+
+        /// <summary>
         /// Initializes the local model library from the state store (sqlite database)
         /// </summary>
         /// <param name="token">Cancellation token</param>
@@ -176,16 +200,11 @@ namespace Cognite.Simulator.Utils
                     true,
                     token).ConfigureAwait(false);
 
+
+                await RestoreExtractionState(token).ConfigureAwait(false);
+
                 await FindModelRevisions(false, token).ConfigureAwait(false);
 
-                await _store.RestoreExtractionState<U, T>(
-                    _state,
-                    _config.FilesTable,
-                    (state, poco) =>
-                    {
-                        state.Init(poco);
-                    },
-                    token).ConfigureAwait(false);
                 if (_store is LiteDBStateStore ldbStore)
                 {
                     HashSet<string> idsToKeep = new HashSet<string>(_state.Select(s => s.Value.Id));

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -169,16 +169,20 @@ namespace Cognite.Simulator.Utils
             var statesPocos = await _store.GetAllExtractionStates<U>(
                 _config.FilesTable,
                 token).ConfigureAwait(false);
+            var restoredCount = 0;
 
             foreach (var poco in statesPocos)
             {
                 var state = new T();
                 state.Init(poco);
-                _state.TryAdd(state.Id, state);
+                if (_state.TryAdd(state.Id, state))
+                {
+                    restoredCount++;
+                }
             }
 
             _logger.LogDebug("Restored {Restored} extraction state(s) from litedb store {store}",
-                statesPocos.Count(),
+                restoredCount,
                 _config.FilesTable);
         }
 

--- a/Cognite.Simulator.Utils/ModelStateBase.cs
+++ b/Cognite.Simulator.Utils/ModelStateBase.cs
@@ -143,16 +143,6 @@ namespace Cognite.Simulator.Utils
             throw new InvalidOperationException($"Dependency file with ID {fileId} not found in the model state.");
         }
 
-
-        /// <summary>
-        /// Model data associated with this state
-        /// </summary>
-        public SimulatorModelInfo Model => new SimulatorModelInfo()
-        {
-            ExternalId = ModelExternalId,
-            Simulator = Source
-        };
-
         /// <summary>
         /// Initialize this model state using a data object from the state store
         /// </summary>


### PR DESCRIPTION
WHY

When we worked on the recent refactor https://github.com/cognitedata/dotnet-simulator-utils/pull/274 we noticed that we can do some improvements on how we cache/restore to/from local state store (LiteDB)
So far the we restored state from local db store into a memory only after we read all the remote objects from the API. This is unfortunate, as it won't allow us to figure out what models need to be downloaded/processed and due to the recent refactor lead to a major flaw where all the models were re-processed even before the state was restored.

Changes:
1. Restore the in-memory state from LiteDB before doing any API calls
2. [additional change] Save ModelExternalId into the state store (this was missing before)
3. [additional change] Remove redundant `SimulatorModelInfo Model` property (not used), same as `InformationExtracted`. There are no other references to them currently

Now we also added the test to verify that restoration works the way we expect with no extra/redundant API calls/processing.

