### PR TITLE
feat(modellib): support more than 1000 files per model

### DIFF
--- a/Cognite.Simulator.Extensions/FilesExtensions.cs
+++ b/Cognite.Simulator.Extensions/FilesExtensions.cs
@@ -23,7 +23,7 @@ public static class FilesExtensions
 
     /// <summary>
     /// Retrieves file medatadata by their IDs in chunks, ignores unknown IDs.
-    /// Each batch can contain up to 1000 file IDs and is be processed in parallel (up to 5 batches at a time).
+    /// Each batch can contain up to 1000 file IDs and is processed in parallel to others (up to 5 batches at a time).
     /// </summary>
     /// <param name="cdfFiles">The FilesResource instance.</param>
     /// <param name="internalIds">The list of internal IDs of the files to retrieve.</param>
@@ -51,7 +51,7 @@ public static class FilesExtensions
             (chunk, _) => async () =>
             {
                 var found = await cdfFiles
-                    .RetrieveAsync(chunk, true, token)
+                    .RetrieveAsync(chunk, ignoreUnknownIds: true, token)
                     .ConfigureAwait(false);
                 foreach (var file in found)
                 {

--- a/Cognite.Simulator.Extensions/FilesExtensions.cs
+++ b/Cognite.Simulator.Extensions/FilesExtensions.cs
@@ -1,5 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Cognite.Extractor.Common;
+
+using CogniteSdk.Resources;
 
 namespace Cognite.Simulator.Extensions;
 
@@ -9,6 +17,52 @@ namespace Cognite.Simulator.Extensions;
 /// </summary>
 public static class FilesExtensions
 {
+    private const int THROTTLE_SIZE = 5;
+    private const int CHUNK_SIZE = 1000;
+
+    /// <summary>
+    /// Retrieves file medatadata by their IDs in chunks, ignores unknown IDs.
+    /// Each batch can contain up to 1000 file IDs and is be processed in parallel (up to 5 batches at a time).
+    /// </summary>
+    /// <param name="cdfFiles">The FilesResource instance.</param>
+    /// <param name="internalIds">The list of internal IDs of the files to retrieve.</param>
+    /// <param name="chunkSize">The maximum number of file IDs to include in each chunk. Default is 1000.</param>
+    /// <param name="token">The cancellation token.</param>
+    public static async Task<List<CogniteSdk.File>> RetrieveBatchAsync(
+        this FilesResource cdfFiles,
+        IList<long> internalIds,
+        int chunkSize = CHUNK_SIZE,
+        CancellationToken token = default
+    )
+    {
+        var result = new List<CogniteSdk.File>();
+        object mutex = new object();
+
+        if (internalIds == null || internalIds.Count == 0)
+        {
+            return result;
+        }
+
+        var fileIdsByChunks = internalIds
+            .ChunkBy(chunkSize);
+
+        var generators = fileIdsByChunks
+            .Select<IEnumerable<long>, Func<Task>>(
+            (chunk, _) => async () =>
+            {
+                var found = await cdfFiles
+                    .RetrieveAsync(chunk, true, token)
+                    .ConfigureAwait(false);
+                lock (mutex)
+                {
+                    result.AddRange(found);
+                }
+            });
+
+        await generators.RunThrottled(THROTTLE_SIZE, token).ConfigureAwait(false);
+
+        return result;
+    }
 
     /// <summary>
     /// Returns the file extension of a given CDF file.

--- a/Cognite.Simulator.Utils/ModelLibraryBase.cs
+++ b/Cognite.Simulator.Utils/ModelLibraryBase.cs
@@ -627,8 +627,8 @@ namespace Cognite.Simulator.Utils
                 modelState.DownloadAttempts);
 
             var files = await _cdfFiles
-                .RetrieveAsync(idsToDownload, ignoreUnknownIds: true)
-                .ConfigureAwait(false); // TODO: make batch version to support more than 1k https://cognitedata.atlassian.net/browse/POFSP-1139
+                .RetrieveBatchAsync(idsToDownload)
+                .ConfigureAwait(false);
 
             var filesMap = files.ToDictionarySafe(file => file.Id, file => file);
 


### PR DESCRIPTION
One model can consist of 1000+ files. Currently we download them one by one to not stress the API and this PR doesn't change the behaviour.

One limitation that we have is that `files.RetrieveAsync` doesn't support getting metadata of more than 1000 files at once.
This is a safe operation to do concurrently, so I am adding an extension method to support chunking.

I replaced the method call, so the lines are covered by the previous tests, though I added one more for a happy path as well.