### PR TITLE
fix(connector-runtime): update ModelDependencies definition on startup

### DIFF
--- a/Cognite.Simulator.Extensions/Cognite.Simulator.Extensions.csproj
+++ b/Cognite.Simulator.Extensions/Cognite.Simulator.Extensions.csproj
@@ -23,7 +23,7 @@
   </ItemGroup> 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="7.0.300" />
-    <PackageReference Include="CogniteSdk" Version="5.2.2" />
+    <PackageReference Include="CogniteSdk" Version="5.3.0" />
     <!-- <ProjectReference Include="..\..\cognite-sdk-dotnet\CogniteSdk\src\CogniteSdk.csproj" /> -->
     <PackageReference Include="Cognite.Extensions" Version="1.35.0" />
     <!-- <ProjectReference Include="..\..\dotnet-extractor-utils\Cognite.Extensions\Cognite.Extensions.csproj" /> -->

--- a/Cognite.Simulator.Tests/ExtensionsTests/SimulatorsTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/SimulatorsTest.cs
@@ -24,7 +24,7 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
 
             using var provider = services.BuildServiceProvider();
             var cdf = provider.GetRequiredService<Client>();
-            var simulator = SeedData.SimulatorCreate;
+            var simulator = SeedData.GetSimulatorCreate(SeedData.TestSimulatorExternalId);
 
             simulator.ModelDependencies = [
                 new SimulatorModelDependency()

--- a/Cognite.Simulator.Tests/ExtensionsTests/SimulatorsTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/SimulatorsTest.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Cognite.Simulator.Extensions;
+
+using CogniteSdk;
+using CogniteSdk.Alpha;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit;
+
+namespace Cognite.Simulator.Tests.ExtensionsTests
+{
+    [Collection(nameof(SequentialTestCollection))]
+    public class SimulatorsTest
+    {
+        [Fact]
+        public async Task TestUpsertSimulators()
+        {
+            var services = new ServiceCollection();
+            services.AddCogniteTestClient();
+
+            using var provider = services.BuildServiceProvider();
+            var cdf = provider.GetRequiredService<Client>();
+            var simulator = SeedData.SimulatorCreate;
+
+            simulator.ModelDependencies = [
+                new SimulatorModelDependency()
+                {
+                    FileExtensionTypes = ["xml"],
+                    Fields = [new SimulatorModelDependencyField()
+                    {
+                        Name = "input1",
+                        Info = "input1 information",
+                        Label = "Input1"
+                    }]
+                }
+            ];
+
+            try
+            {
+                var res = await cdf.Alpha.Simulators.UpsertAsync(simulator, CancellationToken.None);
+                var res2 = await cdf.Alpha.Simulators.UpsertAsync(simulator, CancellationToken.None); // Upsert again to check idempotency
+
+                // Assert created resource
+                Assert.Equal(simulator.ExternalId, res.ExternalId);
+                Assert.Equal(simulator.Name, res.Name);
+
+                Assert.Equal(simulator.FileExtensionTypes, res.FileExtensionTypes);
+                Assert.Equal(simulator.ModelTypes.Select(mt => mt.ToString()), res.ModelTypes.Select(mt => mt.ToString()));
+                Assert.Equal(simulator.ModelDependencies.Select(md => md.ToString()), res.ModelDependencies.Select(md => md.ToString()));
+                Assert.Equal(simulator.StepFields.Select(sf => sf.ToString()), res.StepFields.Select(sf => sf.ToString()));
+                Assert.Equal(simulator.UnitQuantities.Select(uq => uq.ToString()), res.UnitQuantities.Select(uq => uq.ToString()));
+
+                // Assert idempotency
+                Assert.True(res2.LastUpdatedTime > res.LastUpdatedTime); // Last updated time should be updated
+                res.LastUpdatedTime = res2.LastUpdatedTime = 0; // Ignore created time in comparison
+                Assert.Equal(res.ToString(), res2.ToString());
+            }
+            finally
+            {
+                // Cleanup created resources
+                await SeedData.DeleteSimulator(cdf, simulator.ExternalId);
+            }
+        }
+    }
+}

--- a/Cognite.Simulator.Tests/SeedData.cs
+++ b/Cognite.Simulator.Tests/SeedData.cs
@@ -840,10 +840,12 @@ namespace Cognite.Simulator.Tests
             };
         }
 
-        public static SimulatorCreate SimulatorCreate = new SimulatorCreate()
+        public static SimulatorCreate SimulatorCreate = GetSimulatorCreate(TestSimulatorExternalId);
+
+        public static SimulatorCreate GetSimulatorCreate(string externalId) => new SimulatorCreate()
         {
-            ExternalId = TestSimulatorExternalId,
-            Name = TestSimulatorExternalId,
+            ExternalId = externalId,
+            Name = externalId,
             FileExtensionTypes = new List<string> { "out" },
             StepFields = new List<SimulatorStepField> {
                 new SimulatorStepField {

--- a/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ConnectorRuntimeUnitTest.cs
@@ -70,7 +70,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
             // Check the logs, it should first succeed on the startup, then fail and restart
             VerifyLog(mockedLogger, LogLevel.Information, "Starting the connector...", Times.Once());
             VerifyLog(mockedLogger, LogLevel.Information, "Connector can reach CDF!", Times.Once());
-            VerifyLog(mockedLogger, LogLevel.Debug, "Updating simulator definition", Times.Once());
+            VerifyLog(mockedLogger, LogLevel.Information, "Simulator definition upserted to remote", Times.Once(), true);
             VerifyLog(mockedLogger, LogLevel.Error, "Request to CDF failed with code 410", Times.Once(), true);
             VerifyLog(mockedLogger, LogLevel.Warning, "Restarting connector in 10 seconds", Times.AtLeastOnce());
         }


### PR DESCRIPTION
When connector starts-up it normally upserts the "Simulator" definition on remote. In the recent update we added a `ModelDependencies` property, but we forgot to update them on startup. This fixes that, also moved the implementation to the `SimulatorsExtensions` class as it makes sense to keep it closer to ther similar extensions.