### PR TITLE
chore(routine-lib): use long while adding routine revisions into memory

### DIFF
--- a/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/ModelLibraryTest.cs
@@ -384,8 +384,8 @@ namespace Cognite.Simulator.Tests.UtilsTests
                 lib.PaginationLimit = 1;
                 await lib.Init(source.Token);
 
-                Assert.Contains(revision.Id.ToString(), lib.RoutineRevisions);
-                Assert.Contains(revision2.Id.ToString(), lib.RoutineRevisions);
+                Assert.Contains(revision.Id, lib.RoutineRevisions);
+                Assert.Contains(revision2.Id, lib.RoutineRevisions);
                 Assert.Equal(2, lib.RoutineRevisions.Count);
 
                 // Start the library update loop that download and parses the files, stop after 5 secs


### PR DESCRIPTION
We were referencing routine revision items by their ids, but used string as a key in dictionary.
This change will use long id directly, making the code a bit cleaner.
