### PR TITLE
fix(routine-library): optimise memory consumption [POFSP-1221]

### DIFF
--- a/Cognite.Simulator.Extensions/Types.cs
+++ b/Cognite.Simulator.Extensions/Types.cs
@@ -29,37 +29,37 @@ namespace Cognite.Simulator.Extensions
         /// <summary>
         /// The unique identifier of the routine revision.
         /// </summary>
-        public long Id { get; set; }
+        public long Id { get; private set; }
 
         /// <summary>
         /// Routine revision external id
         /// </summary>
-        public string ExternalId { get; set; }
+        public string ExternalId { get; private set; }
 
         /// <summary>
         /// Routine external id
         /// </summary>
-        public string RoutineExternalId { get; set; }
+        public string RoutineExternalId { get; private set; }
 
         /// <summary>
         /// The external id of the simulator integration.
         /// </summary>
-        public string SimulatorIntegrationExternalId { get; set; }
+        public string SimulatorIntegrationExternalId { get; private set; }
 
         /// <summary>
         /// Schedule configuration.
         /// </summary>
-        public SimulatorRoutineRevisionSchedule Schedule { get; set; }
+        public SimulatorRoutineRevisionSchedule Schedule { get; private set; }
 
         /// <summary>
         /// Simulator model associated with this routine
         /// </summary>
-        public SimulatorModelInfo Model { get; set; }
+        public SimulatorModelInfo Model { get; private set; }
 
         /// <summary>
         /// Creation time in milliseconds since epoch
         /// </summary>
-        public long CreatedTime { get; set; }
+        public long CreatedTime { get; private set; }
 
         /// <summary>
         /// Creates a SimulatorRoutineRevisionInfo from a SimulatorRoutineRevision instance

--- a/Cognite.Simulator.Extensions/Types.cs
+++ b/Cognite.Simulator.Extensions/Types.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+
+using CogniteSdk.Alpha;
 
 namespace Cognite.Simulator.Extensions
 {
@@ -25,6 +27,11 @@ namespace Cognite.Simulator.Extensions
     public class SimulatorRoutineRevisionInfo
     {
         /// <summary>
+        /// The unique identifier of the routine revision.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
         /// Routine revision external id
         /// </summary>
         public string ExternalId { get; set; }
@@ -35,9 +42,47 @@ namespace Cognite.Simulator.Extensions
         public string RoutineExternalId { get; set; }
 
         /// <summary>
+        /// The external id of the simulator integration.
+        /// </summary>
+        public string SimulatorIntegrationExternalId { get; set; }
+
+        /// <summary>
+        /// Schedule configuration.
+        /// </summary>
+        public SimulatorRoutineRevisionSchedule Schedule { get; set; }
+
+        /// <summary>
         /// Simulator model associated with this routine
         /// </summary>
         public SimulatorModelInfo Model { get; set; }
+
+        /// <summary>
+        /// Creation time in milliseconds since epoch
+        /// </summary>
+        public long CreatedTime { get; set; }
+
+        /// <summary>
+        /// Creates a SimulatorRoutineRevisionInfo from a SimulatorRoutineRevision instance
+        /// </summary>
+        public SimulatorRoutineRevisionInfo(SimulatorRoutineRevision revision)
+        {
+            if (revision == null)
+            {
+                throw new ArgumentNullException(nameof(revision));
+            }
+
+            Id = revision.Id;
+            ExternalId = revision.ExternalId;
+            RoutineExternalId = revision.RoutineExternalId;
+            SimulatorIntegrationExternalId = revision.SimulatorIntegrationExternalId;
+            Schedule = revision.Configuration?.Schedule;
+            Model = new SimulatorModelInfo
+            {
+                ExternalId = revision.ModelExternalId,
+                Simulator = revision.SimulatorExternalId
+            };
+            CreatedTime = revision.CreatedTime;
+        }
 
         /// <summary>
         /// Routine external id with special characters replaced

--- a/Cognite.Simulator.Tests/ExtensionsTests/TimeSeriesTest.cs
+++ b/Cognite.Simulator.Tests/ExtensionsTests/TimeSeriesTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Cognite.Simulator.Extensions;
 
 using CogniteSdk;
+using CogniteSdk.Alpha;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,17 +27,16 @@ namespace Cognite.Simulator.Tests.ExtensionsTests
             var cdf = provider.GetRequiredService<Client>();
             var timeSeries = cdf.TimeSeries;
 
-            var model = new SimulatorModelInfo
-            {
-                ExternalId = "Connector_Test_Model",
-                Simulator = "TestSimulator"
-            };
-            var routineRevisionInfo = new SimulatorRoutineRevisionInfo
-            {
-                Model = model,
-                ExternalId = "TestCalc - 1",
-                RoutineExternalId = "TestCalc",
-            };
+            var routineRevisionInfo = new SimulatorRoutineRevisionInfo(
+                new SimulatorRoutineRevision
+                {
+                    Id = 123,
+                    ExternalId = "TestCalc - 1",
+                    SimulatorExternalId = "TestSimulator",
+                    ModelExternalId = "Connector_Test_Model",
+                    RoutineExternalId = "TestCalc",
+                }
+            );
 
             var inA = new SimulationInput
             {

--- a/Cognite.Simulator.Utils/RoutineLibraryBase.cs
+++ b/Cognite.Simulator.Utils/RoutineLibraryBase.cs
@@ -27,7 +27,7 @@ namespace Cognite.Simulator.Utils
         where V : SimulatorRoutineRevision
     {
         /// <inheritdoc/>
-        public ConcurrentDictionary<long, V> RoutineRevisions { get; }
+        public ConcurrentDictionary<long, SimulatorRoutineRevisionInfo> RoutineRevisions { get; }
 
         private readonly ILogger _logger;
         private readonly RoutineLibraryConfig _config;
@@ -68,7 +68,7 @@ namespace Cognite.Simulator.Utils
             _config = config;
 
             CdfSimulatorResources = cdf.CogniteClient.Alpha.Simulators;
-            RoutineRevisions = new ConcurrentDictionary<long, V>();
+            RoutineRevisions = new ConcurrentDictionary<long, SimulatorRoutineRevisionInfo>();
             LibState = new BaseExtractionState("RoutineLibraryState");
             _simulatorDefinition = simulatorDefinition;
         }
@@ -83,13 +83,15 @@ namespace Cognite.Simulator.Utils
             await ReadRoutineRevisions(true, token).ConfigureAwait(false);
         }
 
+
         /// <summary>
-        /// Fetch routine revisions from CDF and store them in memory and state store
-        /// This method is used to populate the local routine library with the latest routine revisions "on demand", i.e. right upon simulation run
+        /// Fetches full routine revision information from CDF, given its external ID.
         /// </summary>
-        private async Task<V> TryReadRemoteRoutineRevision(string routineRevisionExternalId)
+        public async Task<V> GetRoutineRevision(
+            string routineRevisionExternalId
+        )
         {
-            _logger.LogInformation("Local routine revision {Id} not found, attempting to fetch from remote", routineRevisionExternalId);
+            _logger.LogDebug("Fetching routine revision {Id} from remote", routineRevisionExternalId);
             try
             {
                 var routineRevisionRes = await CdfSimulatorResources.RetrieveSimulatorRoutineRevisionsAsync(
@@ -98,7 +100,7 @@ namespace Cognite.Simulator.Utils
                 var routineRevision = routineRevisionRes.FirstOrDefault();
                 if (routineRevision != null)
                 {
-                    return ReadAndSaveRoutineRevision(routineRevision);
+                    return LocalConfigurationFromRoutine(routineRevision);
                 }
             }
             catch (CogniteException e)
@@ -109,24 +111,6 @@ namespace Cognite.Simulator.Utils
         }
 
         /// <summary>
-        /// Looks for the routine revision in the memory with the given external ID. If not found, tries to fetch it from CDF.
-        /// </summary>
-        public async Task<V> GetRoutineRevision(
-            string routineRevisionExternalId
-        )
-        {
-            var revisions = RoutineRevisions.Values.Where(c => c.ExternalId == routineRevisionExternalId).OrderByDescending(c => c.CreatedTime);
-            if (revisions.Any())
-            {
-                return revisions.First();
-            }
-
-            V calcConfig = await TryReadRemoteRoutineRevision(routineRevisionExternalId).ConfigureAwait(false);
-
-            return calcConfig;
-        }
-
-        /// <summary>
         /// Verifies that the routine revision exists in CDF.
         /// In case it does not, should remove from memory.
         /// <param name="config">Configuration object</param>
@@ -134,7 +118,7 @@ namespace Cognite.Simulator.Utils
         /// <returns><c>true</c> in case the configuration exists in CDF, <c>false</c> otherwise</returns>
         /// </summary>
         public async Task<bool> VerifyInMemoryCache(
-            V config,
+            SimulatorRoutineRevisionInfo config,
             CancellationToken token)
         {
             if (config == null)
@@ -160,7 +144,7 @@ namespace Cognite.Simulator.Utils
             if (!exists)
             {
                 _logger.LogWarning("Removing {Model} - {Routine} routine revision, not found in CDF",
-                    config.ModelExternalId,
+                    config.Model.ExternalId,
                     config.ExternalId);
                 RoutineRevisions.TryRemove(config.Id, out _);
             }
@@ -208,12 +192,11 @@ namespace Cognite.Simulator.Utils
             return (V)routineRevision;
         }
 
-        private V ReadAndSaveRoutineRevision(SimulatorRoutineRevision routineRev)
+        private void ReadAndSaveRoutineRevision(SimulatorRoutineRevision routineRev)
         {
+            var newRevision = new SimulatorRoutineRevisionInfo(routineRev);
 
-            V newRevision = LocalConfigurationFromRoutine(routineRev);
-
-            var result = RoutineRevisions.AddOrUpdate(routineRev.Id, newRevision, (key, oldValue) =>
+            RoutineRevisions.AddOrUpdate(routineRev.Id, newRevision, (key, oldValue) =>
             {
                 if (newRevision.CreatedTime < oldValue.CreatedTime)
                 {
@@ -221,8 +204,6 @@ namespace Cognite.Simulator.Utils
                 }
                 return newRevision;
             });
-
-            return result;
         }
 
         private async Task ReadRoutineRevisions(bool init, CancellationToken token)
@@ -255,7 +236,6 @@ namespace Cognite.Simulator.Utils
                         CreatedTime = new CogniteSdk.TimeRange() { Min = createdAfter + 1 },
                     },
                     Limit = PaginationLimit,
-                    IncludeAllFields = true
                 },
                 CdfSimulatorResources.ListSimulatorRoutineRevisionsAsync,
                 token);
@@ -320,9 +300,10 @@ namespace Cognite.Simulator.Utils
     public interface IRoutineProvider<V>
     {
         /// <summary>
-        /// Dictionary of simulation routines. The key is the routine revision id
+        /// Dictionary of routine revisions info. The key is the routine revision ID.
+        /// This only includes some basic information about the routine revision, and not larger fields such as script, configuration inputs or outputs.
         /// </summary>
-        ConcurrentDictionary<long, V> RoutineRevisions { get; }
+        ConcurrentDictionary<long, SimulatorRoutineRevisionInfo> RoutineRevisions { get; }
 
         /// <summary>
         /// Initializes the library
@@ -346,9 +327,9 @@ namespace Cognite.Simulator.Utils
         /// Verify that the routine revision exists in CDF.
         /// In case it does not, should remove from memory.
         /// </summary>
-        /// <param name="config">Configuration object</param>
+        /// <param name="routineRevision">Routine revision info object</param>
         /// <param name="token">Cancellation token</param>
         /// <returns><c>true</c> in case the configuration exists in CDF, <c>false</c> otherwise</returns>
-        Task<bool> VerifyInMemoryCache(V config, CancellationToken token);
+        Task<bool> VerifyInMemoryCache(SimulatorRoutineRevisionInfo routineRevision, CancellationToken token);
     }
 }

--- a/Cognite.Simulator.Utils/RoutineRunnerBase.cs
+++ b/Cognite.Simulator.Utils/RoutineRunnerBase.cs
@@ -121,16 +121,7 @@ namespace Cognite.Simulator.Utils
             var outputTsToCreate = new List<SimulationOutput>();
             var inputTsToCreate = new List<SimulationInput>();
             Dictionary<Identity, IEnumerable<Datapoint>> dpsToCreate = new Dictionary<Identity, IEnumerable<Datapoint>>();
-            var routineRevisionInfo = new SimulatorRoutineRevisionInfo()
-            {
-                ExternalId = routineRevision.ExternalId,
-                Model = new SimulatorModelInfo
-                {
-                    ExternalId = modelState.ModelExternalId,
-                    Simulator = routineRevision.SimulatorExternalId,
-                },
-                RoutineExternalId = routineRevision.RoutineExternalId,
-            };
+            var routineRevisionInfo = new SimulatorRoutineRevisionInfo(routineRevision);
 
             var configObj = routineRevision.Configuration;
 


### PR DESCRIPTION
So far we've been saving all the latest version of routines in memory.
This used to work fine and was needed to read the cron params and schedule routine executions based on that. This in-memory cache was also used to run the simulation.

Going forward we might start having larger (few MBs routine revisions) or having simply much larger amount of routines in total.
So to eliminate any future out-of-memory issues with change the logic to only store the most important fields (`IncludeAllFields=false` while listing the latest versions).
Afterwards we store the relevant fields into `SimulatorRoutineRevisionInfo` abstraction.

In order to run a simulation, we'll make a direct call to the API instead of fetching the routine from memory.

Tests: I consider this being covered by the current integration test suite as it's mostly a refactor