### PR TITLE
[SEC-4668] Fix Nuget package signing by updating code sign github action to v5.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,11 +107,11 @@ jobs:
         env:
           CERTIFICATE_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
           CERTIFICATE_HOST_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
+          CERTIFICATE_FINGERPRINT: ${{ secrets.CODE_SIGNING_CERT_SHA256_HASH }}
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
           KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
-        uses: cognitedata/code-sign-action/@5f2df722040f2a061476cf171f67ec6014382f2b # v3
+        uses: cognitedata/code-sign-action/@a29458b69495966f90920f07aeed5acfe03e1f45 # v5
         with:
           path-to-binary: 'nuget-packages/'
 


### PR DESCRIPTION
_Action from the [incident INC-2101](https://app.incident.io/cognitedata/incidents/2101)_

The signing code code is broken for the Nuget packages. Update version of the code-sign-action provides a fix.

Changes:
 - Update code-sign-action github action to a fixed v5 version.