### PR TITLE
fix: add timeout mechanism for OpenServer Shutdown

### DIFF
--- a/Cognite.Simulator.Tests/UtilsTests/AutomationUtilsUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/AutomationUtilsUnitTest.cs
@@ -59,7 +59,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
         }
 
         [WindowsOnlyFact]
-        public void Shutdown_WhenPreShutdownThrows_AndServerIsNotNull_LogsWarningAndReleasesComObject()
+        public void Shutdown_WhenPreShutdownThrows_AndServerIsNotNull_LogsWarningAndSkipsComRelease()
         {
             var mockServer = new object();
             var mockClient = CreateMockClient();
@@ -89,9 +89,9 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
             Assert.Null(exception);
             mockClient.Protected().Verify("PreShutdown", Times.Once());
-            mockClient.Protected().Verify("ReleaseComObject", Times.Once());
+            mockClient.Protected().Verify("ReleaseComObject", Times.Never());
             VerifyLog(_mockLogger, LogLevel.Warning, "Exception during OpenServer shutdown", Times.Once(), true);
-            VerifyLog(_mockLogger, LogLevel.Debug, "Released COM Object", Times.Once(), true);
+            VerifyLog(_mockLogger, LogLevel.Debug, "Released COM Object", Times.Never(), true);
             VerifyLog(_mockLogger, LogLevel.Debug, "Automation server instance removed", Times.Once(), true);
         }
 

--- a/Cognite.Simulator.Tests/UtilsTests/AutomationUtilsUnitTest.cs
+++ b/Cognite.Simulator.Tests/UtilsTests/AutomationUtilsUnitTest.cs
@@ -42,7 +42,7 @@ namespace Cognite.Simulator.Tests.UtilsTests
         }
 
         [WindowsOnlyFact]
-        public void Shutdown_WhenPreShutdownThrows_AndServerIsNull_SkipsComRelease()
+        public void Shutdown_WhenPreShutdownThrows_AndServerIsNull_LogsWarningAndSkipsComRelease()
         {
             var mockClient = CreateMockClient();
             mockClient.Protected()
@@ -51,15 +51,15 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
             var exception = Record.Exception(() => mockClient.Object.Shutdown());
 
-            Assert.NotNull(exception);
-            Assert.Equal("PreShutdown failed", exception.Message);
+            Assert.Null(exception);
             mockClient.Protected().Verify("PreShutdown", Times.Once());
+            VerifyLog(_mockLogger, LogLevel.Warning, "Exception during OpenServer shutdown", Times.Once(), true);
             VerifyLog(_mockLogger, LogLevel.Debug, "Released COM Object", Times.Never(), true);
-            VerifyLog(_mockLogger, LogLevel.Debug, "Automation server instance removed", Times.Never(), true);
+            VerifyLog(_mockLogger, LogLevel.Debug, "Automation server instance removed", Times.Once(), true);
         }
 
         [WindowsOnlyFact]
-        public void Shutdown_WhenPreShutdownThrows_AndServerIsNotNull_ReleasesComObject()
+        public void Shutdown_WhenPreShutdownThrows_AndServerIsNotNull_LogsWarningAndReleasesComObject()
         {
             var mockServer = new object();
             var mockClient = CreateMockClient();
@@ -87,11 +87,27 @@ namespace Cognite.Simulator.Tests.UtilsTests
 
             var exception = Record.Exception(() => mockClient.Object.Shutdown());
 
-            Assert.NotNull(exception);
-            Assert.Equal("PreShutdown failed", exception.Message);
+            Assert.Null(exception);
             mockClient.Protected().Verify("PreShutdown", Times.Once());
             mockClient.Protected().Verify("ReleaseComObject", Times.Once());
+            VerifyLog(_mockLogger, LogLevel.Warning, "Exception during OpenServer shutdown", Times.Once(), true);
             VerifyLog(_mockLogger, LogLevel.Debug, "Released COM Object", Times.Once(), true);
+            VerifyLog(_mockLogger, LogLevel.Debug, "Automation server instance removed", Times.Once(), true);
+        }
+
+        [WindowsOnlyFact]
+        public void Shutdown_WhenPreShutdownHangs_TimesOutAndLogsWarning()
+        {
+            var mockClient = CreateMockClient();
+            mockClient.Protected()
+                .Setup("PreShutdown")
+                .Callback(() => System.Threading.Thread.Sleep(TimeSpan.FromSeconds(15)));
+
+            var exception = Record.Exception(() => mockClient.Object.Shutdown());
+
+            Assert.Null(exception);
+            VerifyLog(_mockLogger, LogLevel.Warning, "OpenServer shutdown timed out", Times.Once(), true);
+            VerifyLog(_mockLogger, LogLevel.Debug, "Automation server instance removed", Times.Once(), true);
         }
 
         [WindowsOnlyFact]


### PR DESCRIPTION
This PR adds a timeout to Shutdown() so the calling thread is not blocked if shutdown hangs. It adds 10-second timeout to `Shutdown()`. If shutdown hangs the method still returns after 10 seconds instead of blocking the thread.