### PR TITLE
Migrate ownership from simulator-integration team to data-management team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cognitedata/simulator-integration
+* @cognitedata/data-management


### PR DESCRIPTION
This is to migrate ownership from simulator-integration team to data-management team as simint has been merged into the data-management team.